### PR TITLE
Fix mobile logo overflow with 5% margin

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -263,6 +263,31 @@ const { html: taglineAnimatedHtml, cursorSec: taglineEndSec } = injectGlyphsSequ
         animation-duration: var(--taglineGlyphAnimSec);
       }
 
+      /* ── Mobile: keep logo within 90vw (5% margin each side) ── */
+      @media (max-width: 480px) {
+        .logo {
+          padding: 40px 5%;
+        }
+
+        .ascii {
+          font-size: min(26px, 5vw);
+        }
+
+        .rule {
+          font-size: min(26px, 5vw);
+        }
+
+        .tagline {
+          font-size: min(20px, 4vw);
+          letter-spacing: max(1px, 0.8vw);
+          word-spacing: max(2px, 1.6vw);
+        }
+
+        .contact-link {
+          font-size: min(15px, 3.5vw);
+        }
+      }
+
       @media (prefers-reduced-motion: reduce) {
         :global(.logo-glyph) {
           animation: none !important;


### PR DESCRIPTION
## Summary

- Adds responsive CSS for viewports ≤480px to prevent the ASCII logo from overflowing on mobile
- Scales `.ascii` and `.rule` font-size to `min(26px, 5vw)`, tagline to `min(20px, 4vw)`
- Switches `.logo` padding to `40px 5%` on mobile, ensuring 5% horizontal margin on each side (content stays within 90vw)
- Scales down tagline letter-spacing/word-spacing and contact link font-size proportionally

## Test plan

- [ ] View on iPhone SE (375px) — logo should fit within viewport with ~5% margin each side
- [ ] View on iPhone 14 (390px) — same check
- [ ] View on desktop (>480px) — no visual change, original 26px/72px padding preserved
- [ ] Verify the skewed ASCII art doesn't clip at the edges on smallest screens

https://claude.ai/code/session_019PzUyQVXknFzzj7jJbNtKz