### PR TITLE
feat: add pre-event survey to ABC #6 (Lorong AI)

### DIFF
--- a/src/content/events/lorong-ai-apr-2026.md
+++ b/src/content/events/lorong-ai-apr-2026.md
@@ -12,5 +12,9 @@ speakers: []
 hosts: ["Chris Pecaut", "Ian Choo", "YJ Soon", "Trevor Lum", "Jensen"]
 tags: ["meetup"]
 status: "upcoming"
+
+preEventSurvey:
+  url: "https://docs.google.com/forms/d/e/1FAIpQLSc910rtaWJzZfyJgU4YWGfbJziFJd3n1NZEwzFWxNxU2AN3NA/viewform?usp=header"
+  closesAt: 2026-04-20
 ---
 An evening of agentic coding, hands-on building, and community time with Lorong AI.


### PR DESCRIPTION
Adds pre-event survey to the April 23 meetup at Lorong AI.

Changes:
- Added preEventSurvey field with Google Forms URL
- Survey closes April 20, 2026
- Collects topic suggestions from community