### PR TITLE
fix: improve survey UX with QR codes and button styling

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -89,6 +89,7 @@ const events = defineCollection({
     preEventSurvey: z.object({
       url: z.string().optional().default(""),
       closesAt: z.coerce.date().optional(),
+      qrEnabled: z.boolean().optional().default(false),
     }).optional(),
     postEventSurvey: z.object({
       url: z.string().optional().default(""),

--- a/src/content/events/lorong-ai-apr-2026.md
+++ b/src/content/events/lorong-ai-apr-2026.md
@@ -16,5 +16,6 @@ status: "upcoming"
 preEventSurvey:
   url: "https://docs.google.com/forms/d/e/1FAIpQLSc910rtaWJzZfyJgU4YWGfbJziFJd3n1NZEwzFWxNxU2AN3NA/viewform?usp=header"
   closesAt: 2026-04-20
+  qrEnabled: true
 ---
 An evening of agentic coding, hands-on building, and community time with Lorong AI.

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -47,12 +47,14 @@ const pastLearning = past.filter((event) => event.data.kind === "learning");
       display: inline-flex;
       align-items: center;
       gap: 4px;
-      color: var(--text);
-      text-decoration: none;
+      color: var(--accent);
+      text-decoration: underline;
+      font-weight: 500;
     }
 
     .survey-link:hover {
-      color: var(--accent);
+      color: var(--text);
+      text-decoration: none;
     }
 
     .feedback-section {

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -134,11 +134,22 @@ const pastLearning = past.filter((event) => event.data.kind === "learning");
             {event.data.preEventSurvey?.url && (
               <div class="survey-section">
                 <div class="survey-title">📋 Help shape this event</div>
-                <a class="survey-link" href={event.data.preEventSurvey.url} target="_blank" rel="noopener">
-                  Share topic suggestions →
+                
+                {/* QR code for pre-event survey (optional) */}
+                {event.data.preEventSurvey.qrEnabled && (
+                  <div class="qr-section" style="margin-bottom: 16px;">
+                    <QRCode url={event.data.preEventSurvey.url} size={150} />
+                    <div class="qr-label">Scan to share your suggestions</div>
+                  </div>
+                )}
+                
+                {/* Prominent button-style link */}
+                <a class="button button-secondary" href={event.data.preEventSurvey.url} target="_blank" rel="noopener" style="justify-self: start;">
+                  Take Survey <span class="inline-arrow" aria-hidden="true">▶</span>
                 </a>
+                
                 {event.data.preEventSurvey.closesAt && (
-                  <div style="font-size: 0.875rem; color: var(--muted); margin-top: 4px;">
+                  <div style="font-size: 0.875rem; color: var(--muted); margin-top: 8px;">
                     Closes {new Date(event.data.preEventSurvey.closesAt).toLocaleDateString("en-SG", { month: "short", day: "numeric" })}
                   </div>
                 )}


### PR DESCRIPTION
Improves pre-event survey visibility and adds QR code support.

## Changes

### UX Improvements
- Change weak text link to prominent button-style 'Take Survey' button (matches Register button style)
- Add QR code option for pre-event surveys
- Better visual hierarchy in survey section

### Schema Updates
- Add qrEnabled field to preEventSurvey
- Allows any event to optionally show QR code for pre-event surveys

### Event #6 (Lorong AI)
- Enable QR code for pre-event survey
- People can scan at venue or share in chat

## Screenshot
Before: Text link 'Share topic suggestions →' (not obviously clickable)
After: Button 'Take Survey ▶' + QR code + 'Scan to share your suggestions'