### PR TITLE
feat: add Huiliang Lui to community members

### DIFF
--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -76,3 +76,14 @@
   github: ""
   addedAt: "2026-04-24T06:44:56Z"
   featured: false
+
+- id: huiliang-lui
+  name: Huiliang Lui
+  aliases: []
+  tagline: ""
+  company: SG Code Campus
+  website: ""
+  linkedin: https://www.linkedin.com/in/huiliang-lui-51854224/
+  github: https://github.com/jumbomochi
+  addedAt: "2026-04-24T08:40:47Z"
+  featured: false


### PR DESCRIPTION
## Summary
- Adds Huiliang Lui (SG Code Campus) to `src/content/members/members.yaml` per `docs/add-person.md`.
- `id: huiliang-lui` (kebab-case, no collision); `addedAt` set to current UTC timestamp so the entry appears last in the Community list.

## Test plan
- [x] `pnpm check` passes (0 errors)
- [x] `pnpm build` passes (8 pages built)
- [ ] Community page renders the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)