### PR TITLE
showcase: workforce-os note tooltip + follow-up polish

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -88,6 +88,7 @@ const presentations = defineCollection({
     videoUrl: optionalUrlOrPath,
     screenshot: z.string().optional().default(""),
     summary: z.string().optional().default(""),
+    noteTeaser: z.string().optional().default(""),
     links: z.array(z.object({
       label: z.string(),
       url: z.union([z.url(), z.string().regex(/^\/[^\s]*$/)]),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -91,6 +91,7 @@ const presentations = defineCollection({
     links: z.array(z.object({
       label: z.string(),
       url: z.union([z.url(), z.string().regex(/^\/[^\s]*$/)]),
+      note: z.string().optional().default(""),
     })).default([]),
     tags: z.array(z.string()).default([]),
   }),

--- a/src/content/presentations/presentations.yaml
+++ b/src/content/presentations/presentations.yaml
@@ -29,7 +29,7 @@
   videoUrl: ""
   screenshot: /showcase/presentations/workforce-os.jpg
   summary: A file-based multi-agent operating system for a seven-person team. No database, no server — just markdown and git.
-  noteTeaser: Try prompt below yourself to begin.
+  noteTeaser: Design your own agentic workflow — try prompt below yourself to begin.
   links:
     - label: Starter prompt
       url: https://www.agenticbuilders.sg/showcase/presentations/workforce-os-starter-prompt.md

--- a/src/content/presentations/presentations.yaml
+++ b/src/content/presentations/presentations.yaml
@@ -29,6 +29,7 @@
   videoUrl: ""
   screenshot: /showcase/presentations/workforce-os.jpg
   summary: A file-based multi-agent operating system for a seven-person team. No database, no server — just markdown and git.
+  noteTeaser: Design your own agentic workflow — see ⓘ on Starter prompt.
   links:
     - label: Starter prompt
       url: https://www.agenticbuilders.sg/showcase/presentations/workforce-os-starter-prompt.md

--- a/src/content/presentations/presentations.yaml
+++ b/src/content/presentations/presentations.yaml
@@ -32,6 +32,12 @@
   links:
     - label: Starter prompt
       url: https://www.agenticbuilders.sg/showcase/presentations/workforce-os-starter-prompt.md
+      note: |
+        I was asked by quite a number of you in person and via DM to open source workforce-os. I am not going to, because that is exactly against the philosophy of everything I was sharing (build it yourself, customise it to your needs). However, I recognise that not everybody knows where/how to start building. So instead of open sourcing the software, I asked my agent to generate a "starter prompt" for you to use to start building your own system. You can - if you wish - also reference nanoclaw as a starting git repo (but frankly there's no need because it will find the repos itself in plan + extra high effort mode).
+
+        So this is more aligned with my philosophy - learn and build your own thing, for your own needs. This community will all be here to help answer any questions if you get stuck!
+
+        Have fun building!
   tags:
     - agents
     - workflow

--- a/src/content/presentations/presentations.yaml
+++ b/src/content/presentations/presentations.yaml
@@ -39,6 +39,8 @@
         So this is more aligned with my philosophy - learn and build your own thing, for your own needs. This community will all be here to help answer any questions if you get stuck!
 
         Have fun building!
+
+        — Gaurav
   tags:
     - agents
     - workflow

--- a/src/content/presentations/presentations.yaml
+++ b/src/content/presentations/presentations.yaml
@@ -29,7 +29,7 @@
   videoUrl: ""
   screenshot: /showcase/presentations/workforce-os.jpg
   summary: A file-based multi-agent operating system for a seven-person team. No database, no server — just markdown and git.
-  noteTeaser: Design your own agentic workflow — see ⓘ on Starter prompt.
+  noteTeaser: Try prompt below yourself to begin.
   links:
     - label: Starter prompt
       url: https://www.agenticbuilders.sg/showcase/presentations/workforce-os-starter-prompt.md

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -103,8 +103,10 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
                         presentation.data.title
                       )}
                     </span>
-                    {presentation.data.summary && <p class="presentation-summary">{presentation.data.summary}</p>}
-                    <span class="presentation-note-teaser">{presentation.data.noteTeaser}</span>
+                    <div class="presentation-summary-block">
+                      {presentation.data.summary && <p class="presentation-summary">{presentation.data.summary}</p>}
+                      {presentation.data.noteTeaser && <p class="presentation-note-teaser">{presentation.data.noteTeaser}</p>}
+                    </div>
                     <div class="presentation-links-block">
                       <span class="presentation-links-label">Links</span>
                       <div class="presentation-links">
@@ -263,9 +265,19 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
   .presentation-card {
     display: grid;
     gap: 12px;
-    grid-row: span 6;
+    grid-row: span 5;
     grid-template-rows: subgrid;
     padding: 14px 16px;
+  }
+
+  .presentation-summary-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6em;
+  }
+
+  .presentation-summary-block p {
+    margin: 0;
   }
 
   @media (max-width: 720px) {
@@ -293,8 +305,6 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
 
   .presentation-note-teaser {
     color: var(--muted);
-    line-height: 1.4;
-    min-height: 0;
   }
 
   .presentation-note-teaser:empty {

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -294,7 +294,6 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
   .presentation-note-teaser {
     color: var(--muted);
     font-family: var(--font-serif);
-    font-size: 0.85rem;
     font-style: italic;
     line-height: 1.4;
     min-height: 0;

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -439,8 +439,9 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
 
   .link-note-popover {
     background: var(--bg);
-    border: 1px solid var(--line);
+    border: 2px solid var(--accent);
     bottom: calc(100% + 8px);
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
     color: var(--fg);
     display: none;
     font-size: 0.85rem;

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -445,8 +445,8 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
     display: none;
     font-size: 0.85rem;
     left: 0;
-    line-height: 1.5;
-    max-width: min(36ch, 90vw);
+    line-height: 1.75;
+    max-width: min(52ch, 90vw);
     padding: 14px 16px;
     position: absolute;
     width: max-content;

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -440,7 +440,6 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
   .link-note-popover {
     background: var(--bg);
     border: 1px solid var(--line);
-    bottom: calc(100% + 8px);
     color: var(--fg);
     display: none;
     font-size: 0.85rem;
@@ -449,6 +448,7 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
     max-width: min(52ch, 90vw);
     padding: 14px 16px;
     position: absolute;
+    top: calc(100% + 8px);
     width: max-content;
     z-index: 10;
   }

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -293,8 +293,6 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
 
   .presentation-note-teaser {
     color: var(--muted);
-    font-family: var(--font-serif);
-    font-style: italic;
     line-height: 1.4;
     min-height: 0;
   }

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -96,44 +96,39 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
                       )}
                     </span>
                     {presentation.data.summary && <p>{presentation.data.summary}</p>}
-                    <div class="presentation-links">
-                      {presentation.data.slidesUrl && (
-                        <a class="muted-link" href={presentation.data.slidesUrl} target="_blank" rel="noopener">Slides</a>
-                      )}
-                      {presentation.data.videoUrl && (
-                        <a class="muted-link" href={presentation.data.videoUrl} target="_blank" rel="noopener">Video</a>
-                      )}
-                      {presentation.data.url && presentation.data.url !== presentation.data.slidesUrl && (
-                        <a class="muted-link" href={presentation.data.url} target="_blank" rel="noopener">Page</a>
-                      )}
-                      {presentation.data.links.map((link, idx) => {
-                        const noteId = `${presentation.data.id}-note-${idx}`;
-                        const paragraphs = link.note
-                          ? link.note.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean)
-                          : [];
-                        return (
-                          <span class="link-with-note">
-                            <a class="muted-link" href={link.url} target="_blank" rel="noopener">{link.label}</a>
-                            {link.note && (
-                              <>
-                                <button
-                                  type="button"
-                                  class="link-note-trigger"
-                                  popovertarget={noteId}
-                                  aria-label={`About ${link.label}`}
-                                >
-                                  i
-                                </button>
-                                <div class="link-note-popover" popover="auto" id={noteId}>
-                                  {paragraphs.map((para) => (
-                                    <p>{para}</p>
-                                  ))}
-                                </div>
-                              </>
-                            )}
-                          </span>
-                        );
-                      })}
+                    <div class="presentation-links-block">
+                      <span class="presentation-links-label">Follow-ups</span>
+                      <div class="presentation-links">
+                        {presentation.data.slidesUrl && (
+                          <a class="muted-link" href={presentation.data.slidesUrl} target="_blank" rel="noopener">Slides</a>
+                        )}
+                        {presentation.data.videoUrl && (
+                          <a class="muted-link" href={presentation.data.videoUrl} target="_blank" rel="noopener">Video</a>
+                        )}
+                        {presentation.data.url && presentation.data.url !== presentation.data.slidesUrl && (
+                          <a class="muted-link" href={presentation.data.url} target="_blank" rel="noopener">Page</a>
+                        )}
+                        {presentation.data.links.map((link) => {
+                          const paragraphs = link.note
+                            ? link.note.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean)
+                            : [];
+                          return (
+                            <span class={`link-with-note${link.note ? " has-note" : ""}`} tabindex={link.note ? 0 : -1}>
+                              <a class="muted-link" href={link.url} target="_blank" rel="noopener">{link.label}</a>
+                              {link.note && (
+                                <>
+                                  <span class="link-note-trigger" aria-hidden="true">i</span>
+                                  <span class="link-note-popover" role="tooltip">
+                                    {paragraphs.map((para) => (
+                                      <span class="link-note-para">{para}</span>
+                                    ))}
+                                  </span>
+                                </>
+                              )}
+                            </span>
+                          );
+                        })}
+                      </div>
                     </div>
                   </article>
                 );
@@ -347,6 +342,21 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
     color: var(--accent);
   }
 
+  .presentation-links-block {
+    align-self: end;
+    display: grid;
+    gap: 6px;
+  }
+
+  .presentation-links-label {
+    color: var(--muted);
+    font-family: var(--font-serif);
+    font-size: 0.72rem;
+    font-style: italic;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
   .presentation-links {
     display: flex;
     flex-wrap: wrap;
@@ -357,6 +367,12 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
     align-items: center;
     display: inline-flex;
     gap: 6px;
+    position: relative;
+  }
+
+  .link-with-note.has-note {
+    cursor: help;
+    outline: none;
   }
 
   .link-note-trigger {
@@ -365,7 +381,6 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
     border: 1px solid var(--line);
     border-radius: 999px;
     color: var(--muted);
-    cursor: pointer;
     display: inline-flex;
     font-family: var(--font-serif);
     font-size: 0.72rem;
@@ -378,8 +393,8 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
     width: 18px;
   }
 
-  .link-note-trigger:hover,
-  .link-note-trigger:focus-visible {
+  .link-with-note.has-note:hover .link-note-trigger,
+  .link-with-note.has-note:focus-visible .link-note-trigger {
     border-color: var(--accent);
     color: var(--accent);
   }
@@ -387,21 +402,31 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
   .link-note-popover {
     background: var(--bg);
     border: 1px solid var(--line);
+    bottom: calc(100% + 8px);
     color: var(--fg);
-    margin: auto;
-    max-width: 52ch;
-    padding: 20px 24px;
+    display: none;
+    font-size: 0.85rem;
+    left: 0;
+    line-height: 1.5;
+    max-width: min(52ch, 90vw);
+    padding: 14px 16px;
+    position: absolute;
+    width: max-content;
+    z-index: 10;
   }
 
-  .link-note-popover p {
-    margin: 0 0 12px;
+  .link-with-note.has-note:hover .link-note-popover,
+  .link-with-note.has-note:focus-visible .link-note-popover,
+  .link-with-note.has-note:focus-within .link-note-popover {
+    display: block;
   }
 
-  .link-note-popover p:last-child {
+  .link-note-para {
+    display: block;
+    margin-bottom: 10px;
+  }
+
+  .link-note-para:last-child {
     margin-bottom: 0;
-  }
-
-  .link-note-popover::backdrop {
-    background: rgba(0, 0, 0, 0.5);
   }
 </style>

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -106,9 +106,34 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
                       {presentation.data.url && presentation.data.url !== presentation.data.slidesUrl && (
                         <a class="muted-link" href={presentation.data.url} target="_blank" rel="noopener">Page</a>
                       )}
-                      {presentation.data.links.map((link) => (
-                        <a class="muted-link" href={link.url} target="_blank" rel="noopener">{link.label}</a>
-                      ))}
+                      {presentation.data.links.map((link, idx) => {
+                        const noteId = `${presentation.data.id}-note-${idx}`;
+                        const paragraphs = link.note
+                          ? link.note.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean)
+                          : [];
+                        return (
+                          <span class="link-with-note">
+                            <a class="muted-link" href={link.url} target="_blank" rel="noopener">{link.label}</a>
+                            {link.note && (
+                              <>
+                                <button
+                                  type="button"
+                                  class="link-note-trigger"
+                                  popovertarget={noteId}
+                                  aria-label={`About ${link.label}`}
+                                >
+                                  i
+                                </button>
+                                <div class="link-note-popover" popover="auto" id={noteId}>
+                                  {paragraphs.map((para) => (
+                                    <p>{para}</p>
+                                  ))}
+                                </div>
+                              </>
+                            )}
+                          </span>
+                        );
+                      })}
                     </div>
                   </article>
                 );
@@ -326,5 +351,57 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
     display: flex;
     flex-wrap: wrap;
     gap: 12px 18px;
+  }
+
+  .link-with-note {
+    align-items: center;
+    display: inline-flex;
+    gap: 6px;
+  }
+
+  .link-note-trigger {
+    align-items: center;
+    background: transparent;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    color: var(--muted);
+    cursor: pointer;
+    display: inline-flex;
+    font-family: var(--font-serif);
+    font-size: 0.72rem;
+    font-style: italic;
+    font-weight: 700;
+    height: 18px;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+    width: 18px;
+  }
+
+  .link-note-trigger:hover,
+  .link-note-trigger:focus-visible {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .link-note-popover {
+    background: var(--bg);
+    border: 1px solid var(--line);
+    color: var(--fg);
+    margin: auto;
+    max-width: 52ch;
+    padding: 20px 24px;
+  }
+
+  .link-note-popover p {
+    margin: 0 0 12px;
+  }
+
+  .link-note-popover p:last-child {
+    margin-bottom: 0;
+  }
+
+  .link-note-popover::backdrop {
+    background: rgba(0, 0, 0, 0.5);
   }
 </style>

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -440,15 +440,15 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
   .link-note-popover {
     background: var(--bg);
     border: 1px solid var(--line);
+    bottom: calc(100% + 8px);
     color: var(--fg);
     display: none;
     font-size: 0.85rem;
     left: 0;
     line-height: 1.5;
-    max-width: min(52ch, 90vw);
+    max-width: min(36ch, 90vw);
     padding: 14px 16px;
     position: absolute;
-    top: calc(100% + 8px);
     width: max-content;
     z-index: 10;
   }

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -77,17 +77,25 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
                         ))}
                       </span>
                     )}
-                    {presentation.data.screenshot && (
-                      <img
-                        src={presentation.data.screenshot}
-                        alt={`${presentation.data.title} — first slide`}
-                        loading="lazy"
-                        decoding="async"
-                        width="800"
-                        height="450"
-                        class="showcase-image"
-                      />
-                    )}
+                    {presentation.data.screenshot && (() => {
+                      const slideHref = presentation.data.slidesUrl || presentation.data.url || "";
+                      const img = (
+                        <img
+                          src={presentation.data.screenshot}
+                          alt={`${presentation.data.title} — first slide`}
+                          loading="lazy"
+                          decoding="async"
+                          width="800"
+                          height="450"
+                          class="showcase-image"
+                        />
+                      );
+                      return slideHref ? (
+                        <a class="showcase-image-link" href={slideHref} target="_blank" rel="noopener" aria-label={`${presentation.data.title} — open slides`}>
+                          {img}
+                        </a>
+                      ) : img;
+                    })()}
                     <span class="presentation-title">
                       {presentation.data.url ? (
                         <a href={presentation.data.url} target="_blank" rel="noopener">{presentation.data.title}</a>
@@ -95,9 +103,10 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
                         presentation.data.title
                       )}
                     </span>
-                    {presentation.data.summary && <p>{presentation.data.summary}</p>}
+                    {presentation.data.summary && <p class="presentation-summary">{presentation.data.summary}</p>}
+                    <span class="presentation-note-teaser">{presentation.data.noteTeaser}</span>
                     <div class="presentation-links-block">
-                      <span class="presentation-links-label">Follow-ups</span>
+                      <span class="presentation-links-label">Links</span>
                       <div class="presentation-links">
                         {presentation.data.slidesUrl && (
                           <a class="muted-link" href={presentation.data.slidesUrl} target="_blank" rel="noopener">Slides</a>
@@ -254,7 +263,7 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
   .presentation-card {
     display: grid;
     gap: 12px;
-    grid-row: span 5;
+    grid-row: span 6;
     grid-template-rows: subgrid;
     padding: 14px 16px;
   }
@@ -270,8 +279,30 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
     }
   }
 
-  .presentation-links {
-    align-self: end;
+  .showcase-image-link {
+    align-self: start;
+    display: block;
+    justify-self: stretch;
+    width: 100%;
+  }
+
+  .showcase-image-link .showcase-image {
+    display: block;
+    width: 100%;
+  }
+
+  .presentation-note-teaser {
+    color: var(--muted);
+    font-family: var(--font-serif);
+    font-size: 0.85rem;
+    font-style: italic;
+    line-height: 1.4;
+    min-height: 0;
+  }
+
+  .presentation-note-teaser:empty {
+    display: block;
+    min-height: 0;
   }
 
   .event-group-header {
@@ -343,7 +374,7 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
   }
 
   .presentation-links-block {
-    align-self: end;
+    align-self: start;
     display: grid;
     gap: 6px;
   }


### PR DESCRIPTION
## Summary
- Add a hover tooltip on the "Starter prompt" link under Workforce OS with Gaurav K's verbatim note (signed "— Gaurav"), explaining why the repo isn't being open-sourced and how to begin designing your own workflow.
- Add an optional `noteTeaser` field on presentations and populate it for Workforce OS: "Design your own agentic workflow — try prompt below yourself to begin." Renders one paragraph break below the summary, matching summary styling.
- Rename the presentation follow-ups label from "Follow-ups" to "Links".
- Wrap slide thumbnails in an anchor pointing to `slidesUrl` (or `url` fallback) so clicking an image opens the slides directly.
- Polish tooltip styling: accent-colored 2px border, soft drop shadow, line-height 1.75 so the note reads clearly against the card background.
- Align the Links row horizontally within each card row by switching the links block from `align-self: end` to `start` and using subgrid.

## Test plan
- [ ] Hover the ⓘ next to "Starter prompt" on the Workforce OS card — tooltip appears above, signed "— Gaurav".
- [ ] Click a slide thumbnail on any of the four presentation cards — opens slides/deck URL in a new tab.
- [ ] Verify the "Links" label reads "Links" (not "Follow-ups").
- [ ] Verify the Workforce OS card shows the teaser sentence one paragraph break below its summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)