### PR TITLE
Add terminal-style note popovers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ This repo is an Astro site for the Agentic Builders Collective. Keep durable beh
   - `1rem` (15px) for **all** text including cards, body copy, links, headings, metadata, timestamps, code, everything
   - `13px` acceptable only for inline symbols/arrows (e.g., ▶ characters)
 - Box/card backgrounds use `--box-bg: rgba(30, 30, 40, 0.45)` — neutral grey with slight blue tint, 45% opacity
+- Use `src/components/TerminalNoteLink.astro` for link-attached notes/popovers. It codifies the terminal-style `[ℹ]` disclosure, `[×]` close control, dynamic close-corner placement, desktop popover, and mobile inline expansion.
 
 ## Style change policy
 

--- a/src/components/TerminalNoteLink.astro
+++ b/src/components/TerminalNoteLink.astro
@@ -1,0 +1,241 @@
+---
+interface Props {
+  href: string;
+  label: string;
+  note?: string;
+}
+
+const { href, label, note = "" } = Astro.props;
+const paragraphs = note.split(/\n\s*\n/).map((paragraph) => paragraph.trim()).filter(Boolean);
+const hasNote = paragraphs.length > 0;
+---
+
+<div class:list={["terminal-note-link", { "has-note": hasNote }]}>
+  <a class="muted-link" href={href} target="_blank" rel="noopener">{label}</a>
+  {hasNote && (
+    <details class="terminal-note-disclosure">
+      <summary class="terminal-note-trigger" aria-label={`Read note for ${label}`}>[ℹ]</summary>
+      <div class="terminal-note-popover">
+        <div class="terminal-note-content">
+          {paragraphs.map((paragraph) => (
+            <p class="terminal-note-para">{paragraph}</p>
+          ))}
+        </div>
+        <button class="terminal-note-close" type="button" data-terminal-note-close aria-label={`Close note for ${label}`}>[×]</button>
+      </div>
+    </details>
+  )}
+</div>
+
+<script>
+  let activeTerminalNoteDetails = document.createElement("details");
+
+  function updateTerminalNotePlacement() {
+    if (!(activeTerminalNoteDetails instanceof HTMLDetailsElement)) return;
+
+    const trigger = activeTerminalNoteDetails.querySelector(".terminal-note-trigger");
+    const popover = activeTerminalNoteDetails.querySelector(".terminal-note-popover");
+    if (!(trigger instanceof HTMLElement) || !(popover instanceof HTMLElement)) return;
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const popoverRect = popover.getBoundingClientRect();
+    const triggerX = triggerRect.left + triggerRect.width / 2;
+    const triggerY = triggerRect.top + triggerRect.height / 2;
+    const popoverX = popoverRect.left + popoverRect.width / 2;
+    const popoverY = popoverRect.top + popoverRect.height / 2;
+    const vertical = triggerY < popoverY ? "top" : "bottom";
+    const horizontal = triggerX < popoverX ? "left" : "right";
+
+    activeTerminalNoteDetails.dataset.closeCorner = `${vertical}-${horizontal}`;
+  }
+
+  const updateOpenTerminalNotes = () => {
+    document.querySelectorAll(".terminal-note-disclosure[open]").forEach((details) => {
+      if (details instanceof HTMLDetailsElement) {
+        activeTerminalNoteDetails = details;
+        updateTerminalNotePlacement();
+      }
+    });
+  };
+
+  document.addEventListener(
+    "toggle",
+    (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLDetailsElement) || !target.classList.contains("terminal-note-disclosure")) return;
+
+      if (target.open) {
+        activeTerminalNoteDetails = target;
+        requestAnimationFrame(updateTerminalNotePlacement);
+      } else {
+        delete target.dataset.closeCorner;
+      }
+    },
+    true,
+  );
+
+  document.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+
+    const closeButton = target.closest("[data-terminal-note-close]");
+    if (!closeButton) return;
+
+    closeButton.closest("details")?.removeAttribute("open");
+  });
+
+  window.addEventListener("resize", updateOpenTerminalNotes, { passive: true });
+</script>
+
+<style>
+  .terminal-note-link {
+    align-items: center;
+    display: inline-flex;
+    gap: 6px;
+    position: relative;
+  }
+
+  .terminal-note-disclosure {
+    display: inline-flex;
+    position: relative;
+  }
+
+  .terminal-note-trigger {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    color: var(--muted);
+    cursor: pointer;
+    display: inline-flex;
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 400;
+    justify-content: center;
+    line-height: 1.4;
+    list-style: none;
+    padding: 0 0 0 1ch;
+    white-space: nowrap;
+  }
+
+  .terminal-note-trigger::-webkit-details-marker {
+    display: none;
+  }
+
+  .terminal-note-trigger:hover,
+  .terminal-note-trigger:focus-visible,
+  .terminal-note-disclosure[open] .terminal-note-trigger {
+    color: var(--accent);
+    outline: none;
+    text-decoration: underline;
+  }
+
+  .terminal-note-popover {
+    background: var(--bg);
+    border: 2px solid var(--accent);
+    bottom: calc(100% + 8px);
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
+    color: var(--fg);
+    display: none;
+    font-size: 1rem;
+    gap: 10px;
+    grid-template-areas:
+      "content"
+      "close";
+    left: auto;
+    line-height: 1.75;
+    max-width: min(52ch, 90vw);
+    padding: 14px 16px;
+    position: absolute;
+    right: 0;
+    width: max-content;
+    z-index: 10;
+  }
+
+  .terminal-note-disclosure[open] .terminal-note-popover {
+    display: grid;
+  }
+
+  .terminal-note-content {
+    grid-area: content;
+  }
+
+  .terminal-note-para {
+    color: var(--fg);
+    margin-bottom: 10px;
+  }
+
+  .terminal-note-para:last-child {
+    margin-bottom: 0;
+  }
+
+  .terminal-note-close {
+    align-self: end;
+    background: transparent;
+    border: 0;
+    color: var(--muted);
+    cursor: pointer;
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    grid-area: close;
+    justify-self: end;
+    line-height: 1.4;
+    padding: 0;
+  }
+
+  .terminal-note-close:hover,
+  .terminal-note-close:focus-visible {
+    color: var(--accent);
+    outline: none;
+    text-decoration: underline;
+  }
+
+  .terminal-note-disclosure[data-close-corner="top-left"] .terminal-note-popover,
+  .terminal-note-disclosure[data-close-corner="top-right"] .terminal-note-popover {
+    grid-template-areas:
+      "close"
+      "content";
+  }
+
+  .terminal-note-disclosure[data-close-corner="top-left"] .terminal-note-close,
+  .terminal-note-disclosure[data-close-corner="bottom-left"] .terminal-note-close {
+    justify-self: start;
+  }
+
+  .terminal-note-disclosure[data-close-corner="top-right"] .terminal-note-close,
+  .terminal-note-disclosure[data-close-corner="bottom-right"] .terminal-note-close {
+    justify-self: end;
+  }
+
+  @media (max-width: 720px) {
+    .terminal-note-link {
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+
+    .terminal-note-link:has(.terminal-note-disclosure[open]) {
+      width: 100%;
+    }
+
+    .terminal-note-disclosure {
+      display: inline-flex;
+      width: auto;
+    }
+
+    .terminal-note-disclosure[open] {
+      display: block;
+      width: 100%;
+    }
+
+    .terminal-note-popover {
+      bottom: auto;
+      box-shadow: none;
+      left: auto;
+      margin-top: 8px;
+      max-width: 100%;
+      position: static;
+      right: auto;
+      width: 100%;
+    }
+  }
+</style>

--- a/src/components/TerminalNoteLink.astro
+++ b/src/components/TerminalNoteLink.astro
@@ -10,7 +10,7 @@ const paragraphs = note.split(/\n\s*\n/).map((paragraph) => paragraph.trim()).fi
 const hasNote = paragraphs.length > 0;
 ---
 
-<div class:list={["terminal-note-link", { "has-note": hasNote }]}>
+<span class="terminal-note-link">
   <a class="muted-link" href={href} target="_blank" rel="noopener">{label}</a>
   {hasNote && (
     <details class="terminal-note-disclosure">
@@ -25,37 +25,39 @@ const hasNote = paragraphs.length > 0;
       </div>
     </details>
   )}
-</div>
+</span>
 
 <script>
-  let activeTerminalNoteDetails = document.createElement("details");
-
   function updateTerminalNotePlacement() {
-    if (!(activeTerminalNoteDetails instanceof HTMLDetailsElement)) return;
+    document.querySelectorAll(".terminal-note-disclosure[data-placement-pending]").forEach((details) => {
+      if (!(details instanceof HTMLDetailsElement)) return;
 
-    const trigger = activeTerminalNoteDetails.querySelector(".terminal-note-trigger");
-    const popover = activeTerminalNoteDetails.querySelector(".terminal-note-popover");
-    if (!(trigger instanceof HTMLElement) || !(popover instanceof HTMLElement)) return;
+      details.removeAttribute("data-placement-pending");
 
-    const triggerRect = trigger.getBoundingClientRect();
-    const popoverRect = popover.getBoundingClientRect();
-    const triggerX = triggerRect.left + triggerRect.width / 2;
-    const triggerY = triggerRect.top + triggerRect.height / 2;
-    const popoverX = popoverRect.left + popoverRect.width / 2;
-    const popoverY = popoverRect.top + popoverRect.height / 2;
-    const vertical = triggerY < popoverY ? "top" : "bottom";
-    const horizontal = triggerX < popoverX ? "left" : "right";
+      const trigger = details.querySelector(".terminal-note-trigger");
+      const popover = details.querySelector(".terminal-note-popover");
+      if (!(trigger instanceof HTMLElement) || !(popover instanceof HTMLElement)) return;
 
-    activeTerminalNoteDetails.dataset.closeCorner = `${vertical}-${horizontal}`;
+      const triggerRect = trigger.getBoundingClientRect();
+      const popoverRect = popover.getBoundingClientRect();
+      const triggerX = triggerRect.left + triggerRect.width / 2;
+      const triggerY = triggerRect.top + triggerRect.height / 2;
+      const popoverX = popoverRect.left + popoverRect.width / 2;
+      const popoverY = popoverRect.top + popoverRect.height / 2;
+      const vertical = triggerY < popoverY ? "top" : "bottom";
+      const horizontal = triggerX < popoverX ? "left" : "right";
+
+      details.dataset.closeCorner = `${vertical}-${horizontal}`;
+    });
   }
 
   const updateOpenTerminalNotes = () => {
     document.querySelectorAll(".terminal-note-disclosure[open]").forEach((details) => {
       if (details instanceof HTMLDetailsElement) {
-        activeTerminalNoteDetails = details;
-        updateTerminalNotePlacement();
+        details.dataset.placementPending = "true";
       }
     });
+    updateTerminalNotePlacement();
   };
 
   document.addEventListener(
@@ -65,9 +67,10 @@ const hasNote = paragraphs.length > 0;
       if (!(target instanceof HTMLDetailsElement) || !target.classList.contains("terminal-note-disclosure")) return;
 
       if (target.open) {
-        activeTerminalNoteDetails = target;
+        target.dataset.placementPending = "true";
         requestAnimationFrame(updateTerminalNotePlacement);
       } else {
+        delete target.dataset.placementPending;
         delete target.dataset.closeCorner;
       }
     },

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import TerminalNoteLink from "../../components/TerminalNoteLink.astro";
 import { contributionLinks } from "../../lib/contribution-links";
 import { buildEventIndex, buildPeopleIndex, getLinkedEvent, resolvePersonRefs } from "../../lib/relations";
 
@@ -122,26 +123,9 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
                         {presentation.data.url && presentation.data.url !== presentation.data.slidesUrl && (
                           <a class="muted-link" href={presentation.data.url} target="_blank" rel="noopener">Page</a>
                         )}
-                        {presentation.data.links.map((link) => {
-                          const paragraphs = link.note
-                            ? link.note.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean)
-                            : [];
-                          return (
-                            <span class={`link-with-note${link.note ? " has-note" : ""}`} tabindex={link.note ? 0 : -1}>
-                              <a class="muted-link" href={link.url} target="_blank" rel="noopener">{link.label}</a>
-                              {link.note && (
-                                <>
-                                  <span class="link-note-trigger" aria-hidden="true">i</span>
-                                  <span class="link-note-popover" role="tooltip">
-                                    {paragraphs.map((para) => (
-                                      <span class="link-note-para">{para}</span>
-                                    ))}
-                                  </span>
-                                </>
-                              )}
-                            </span>
-                          );
-                        })}
+                        {presentation.data.links.map((link) => (
+                          <TerminalNoteLink href={link.url} label={link.label} note={link.note} />
+                        ))}
                       </div>
                     </div>
                   </article>
@@ -405,73 +389,5 @@ const eventGroups = Array.from(presentationsByEvent.values()).sort(
     display: flex;
     flex-wrap: wrap;
     gap: 12px 18px;
-  }
-
-  .link-with-note {
-    align-items: center;
-    display: inline-flex;
-    gap: 6px;
-    position: relative;
-  }
-
-  .link-with-note.has-note {
-    cursor: help;
-    outline: none;
-  }
-
-  .link-note-trigger {
-    align-items: center;
-    background: transparent;
-    border: 1px solid var(--line);
-    border-radius: 999px;
-    color: var(--muted);
-    display: inline-flex;
-    font-family: var(--font-serif);
-    font-size: 0.72rem;
-    font-style: italic;
-    font-weight: 700;
-    height: 18px;
-    justify-content: center;
-    line-height: 1;
-    padding: 0;
-    width: 18px;
-  }
-
-  .link-with-note.has-note:hover .link-note-trigger,
-  .link-with-note.has-note:focus-visible .link-note-trigger {
-    border-color: var(--accent);
-    color: var(--accent);
-  }
-
-  .link-note-popover {
-    background: var(--bg);
-    border: 2px solid var(--accent);
-    bottom: calc(100% + 8px);
-    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
-    color: var(--fg);
-    display: none;
-    font-size: 0.85rem;
-    left: 0;
-    line-height: 1.75;
-    max-width: min(52ch, 90vw);
-    padding: 14px 16px;
-    position: absolute;
-    width: max-content;
-    z-index: 10;
-  }
-
-  .link-with-note.has-note:hover .link-note-popover,
-  .link-with-note.has-note:focus-visible .link-note-popover,
-  .link-with-note.has-note:focus-within .link-note-popover {
-    display: block;
-  }
-
-  .link-note-para {
-    display: block;
-    margin-bottom: 10px;
-  }
-
-  .link-note-para:last-child {
-    margin-bottom: 0;
   }
 </style>


### PR DESCRIPTION
## Summary
- Add a reusable `TerminalNoteLink` component for terminal-style link notes.
- Replace the Showcase presentation note tooltip with the shared component.
- Document the component in `AGENTS.md` so future agents reuse the pattern.

## Validation
- `pnpm check`
- `git diff --check`
