### PR TITLE
events: add #7 ABC at AmCham Singapore (28 May 2026)

### DIFF
--- a/src/content/events/2026-05-28-abc-at-amcham.md
+++ b/src/content/events/2026-05-28-abc-at-amcham.md
@@ -1,0 +1,17 @@
+---
+title: "#7 - ABC at AmCham Singapore"
+date: 2026-05-28
+kind: "meetup"
+time: "6:00 PM – 9:00 PM SGT"
+venue: "AmCham Singapore @ Shaw Centre"
+venueUrl: "https://maps.app.goo.gl/?q=1+Scotts+Rd+Shaw+Centre+Singapore+228208"
+sponsorName: "American Chamber of Commerce Singapore"
+sponsorUrl: "https://www.amcham.com.sg"
+registrationUrl: "https://luma.com/2q4yargk"
+attendance: 0
+speakers: []
+hosts: ["Chris Pecaut", "Ian Choo", "YJ Soon", "Trevor Lum", "Jensen"]
+tags: ["meetup"]
+status: "upcoming"
+---
+An evening of agentic coding, hands-on building, and community time with friendly folks at AmCham Singapore. Expect practical, applied talks from experienced AI builders using Claude, Codex, Gemini, OpenClaw, and friends — plus space to eat, mingle, and connect.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -473,6 +473,30 @@ const isCurrent = (href: string) => {
         </div>
       </section>
 
+      <!-- Upcoming Event -->
+      <section class="home-section">
+        <h3 class="section-label">Upcoming Event</h3>
+        {upcomingEvent ? (
+          <div class="list-item">
+            <div class="list-item-header">
+              <span class="list-item-title">{upcomingEvent.data.title}</span>
+              <div class="card-meta">
+                <span>{new Date(upcomingEvent.data.date).toLocaleDateString("en-SG", { weekday: "short", year: "numeric", month: "short", day: "numeric" })}</span>
+                {upcomingEvent.data.time && <span>{upcomingEvent.data.time}</span>}
+                {upcomingEvent.data.venue && <span>{upcomingEvent.data.venue}</span>}
+              </div>
+            </div>
+            {upcomingEvent.data.registrationUrl && (
+              <a class="button button-primary home-event-register" href={upcomingEvent.data.registrationUrl} target="_blank" rel="noopener">Register <span class="inline-arrow" aria-hidden="true">▶</span></a>
+            )}
+          </div>
+        ) : (
+          <div class="card">
+            <p>No upcoming events — <a href={whatsappUrl} target="_blank" rel="noopener" style="color:var(--accent);">join the WhatsApp chat</a> to stay updated, or <a class="muted-link" href={contributionLinks.event} target="_blank" rel="noopener">add an event by submitting a pull request</a>.</p>
+          </div>
+        )}
+      </section>
+
       <!-- Getting Started -->
       <section class="home-section" id="getting-started">
         <h3 class="section-label">Getting Started</h3>
@@ -506,30 +530,6 @@ const isCurrent = (href: string) => {
             </div>
           </div>
         </div>
-      </section>
-
-      <!-- Upcoming Event -->
-      <section class="home-section">
-        <h3 class="section-label">Upcoming Event</h3>
-        {upcomingEvent ? (
-          <div class="list-item">
-            <div class="list-item-header">
-              <span class="list-item-title">{upcomingEvent.data.title}</span>
-              <div class="card-meta">
-                <span>{new Date(upcomingEvent.data.date).toLocaleDateString("en-SG", { weekday: "short", year: "numeric", month: "short", day: "numeric" })}</span>
-                {upcomingEvent.data.time && <span>{upcomingEvent.data.time}</span>}
-                {upcomingEvent.data.venue && <span>{upcomingEvent.data.venue}</span>}
-              </div>
-            </div>
-            {upcomingEvent.data.registrationUrl && (
-              <a class="button button-primary home-event-register" href={upcomingEvent.data.registrationUrl} target="_blank" rel="noopener">Register <span class="inline-arrow" aria-hidden="true">▶</span></a>
-            )}
-          </div>
-        ) : (
-          <div class="card">
-            <p>No upcoming events — <a href={whatsappUrl} target="_blank" rel="noopener" style="color:var(--accent);">join the WhatsApp chat</a> to stay updated, or <a class="muted-link" href={contributionLinks.event} target="_blank" rel="noopener">add an event by submitting a pull request</a>.</p>
-          </div>
-        )}
       </section>
 
       <!-- FAQ -->


### PR DESCRIPTION
## Summary
- Add the next ABC meetup as event #7: **ABC at AmCham Singapore**, Thu 28 May 2026, 6–9 PM SGT.
- Venue: AmCham Singapore @ Shaw Centre (1 Scotts Rd #23-03/04/05, Singapore 228208).
- Sponsor/host partner: American Chamber of Commerce Singapore.
- Registration: https://luma.com/2q4yargk
- Move the homepage "Upcoming Event" section above "Getting Started" so first-time visitors see the next meetup before the onboarding steps.

## Test plan
- [ ] Event appears under Upcoming on `/events/`
- [ ] Register button links to the Luma page
- [ ] Sponsor link points to amcham.com.sg
- [ ] Homepage shows Upcoming Event before Getting Started

🤖 Generated with [Claude Code](https://claude.com/claude-code)