### PR TITLE
Add pg_ffmpeg project to showcase

### DIFF
--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -131,3 +131,15 @@
   github: https://github.com/kosmobao
   addedAt: "2026-04-25T10:00:00Z"
   featured: false
+
+- id: han-qiao
+  name: Han Qiao
+  aliases:
+    - sweatybridge
+  tagline: ""
+  company: Supabase
+  website: ""
+  linkedin: https://www.linkedin.com/in/qiao-han-0372932a/
+  github: https://github.com/sweatybridge
+  addedAt: "2026-04-25T14:07:15Z"
+  featured: false

--- a/src/content/projects/pg-ffmpeg.md
+++ b/src/content/projects/pg-ffmpeg.md
@@ -1,0 +1,18 @@
+---
+title: pg_ffmpeg
+makers:
+  - name: Han Qiao
+github: https://github.com/sweatybridge/pg_ffmpeg
+builtWith:
+  - Rust
+  - pgrx
+  - PostgreSQL
+  - FFmpeg
+featured: false
+summary: A PostgreSQL extension that brings FFmpeg media processing into SQL, with safe filter graphs and optional hardware acceleration.
+date: 2026-04-25
+---
+
+pg_ffmpeg is a PostgreSQL extension that exposes FFmpeg's media processing capabilities directly inside the database. It provides SQL functions for extracting metadata and thumbnails, transcoding and remuxing audio and video, trimming with keyframe-aligned or frame-accurate precision, generating waveforms, spectrograms, and animated previews, running complex filter graphs across multiple inputs, concatenating compatible segments, and encoding videos from arrays of image frames.
+
+Built in Rust with the pgrx framework and linked against the FFmpeg libraries, the extension validates filter graphs against an allow-list to keep operations safe, supports hardware acceleration as an opt-in, and includes aggregate functions for ordered concatenation as well as HLS segment generation from remote URLs.

--- a/src/content/projects/pg-ffmpeg.md
+++ b/src/content/projects/pg-ffmpeg.md
@@ -1,7 +1,7 @@
 ---
 title: pg_ffmpeg
 makers:
-  - name: Han Qiao
+  - personId: han-qiao
 github: https://github.com/sweatybridge/pg_ffmpeg
 builtWith:
   - Rust


### PR DESCRIPTION
## Summary
- Adds `src/content/projects/pg-ffmpeg.md` for [pg_ffmpeg](https://github.com/sweatybridge/pg_ffmpeg), a PostgreSQL extension that exposes FFmpeg media processing as SQL functions (transcoding, trimming, thumbnails, waveforms, filter graphs, HLS).
- Maker listed as `name: Han Qiao` (@sweatybridge) since the maker is not yet in `members.yaml`.
- Built with: Rust, pgrx, PostgreSQL, FFmpeg.

## Test plan
- [x] `pnpm check` passes (0 errors)
- [x] `pnpm build` passes

https://claude.ai/code/session_01Cx5o94F759FHY19EnXAyTP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cx5o94F759FHY19EnXAyTP)_