### PR TITLE
[codex] add events and jobs vibe coder job post

### DIFF
--- a/src/content/jobs/events-and-jobs-vibe-coder-agentic-builders-collective.md
+++ b/src/content/jobs/events-and-jobs-vibe-coder-agentic-builders-collective.md
@@ -1,0 +1,71 @@
+---
+title: Events and Jobs Vibe Coder
+company: Agentic Builders Collective
+companyUrl: https://www.agenticbuilders.sg
+location: Singapore / remote
+workMode: hybrid
+employmentType: fractional
+applyUrl: ""
+contactEmail: hello@agenticbuilders.sg
+postedAt: 2026-05-21
+expiresAt: 2026-08-19
+submittedBy:
+  name: Agentic Builders Collective
+tags:
+  - community
+  - agentic-coding
+  - events
+  - jobs
+  - pull-requests
+status: open
+---
+
+Agentic Builders Collective runs on a simple idea: builders should be able to show up, share useful work, and learn the next move in public.
+
+Sometimes that next move starts messily. Someone drops an event announcement in the wrong channel. Someone has a role to share but no idea how to make a pull request. Someone posts something that needs a quick rule check before it belongs anywhere near the site.
+
+We want to turn that messy edge into a clear community pathway. The Events and Jobs Vibe Coder is the person who helps route those posts into clean website pull requests, kindly redirects the humans behind them, and makes the whole process feel like part of the ABC operating system.
+
+## What you will do
+
+- Receive event and job posts forwarded by organisers.
+- Sanity-check whether the post belongs on the site, and flag or discard anything spammy, rule-breaking, vague, or off-mission.
+- Turn valid event and job submissions into small, tidy pull requests against the ABC website.
+- Privately let the original poster know what happened, where their post went, and how they can do it themselves next time.
+- Help non-technical contributors get started with AI-assisted posting when they are willing and available.
+- When useful, jump on a short call to get someone from "I have a thing to share" to "I can use an agent to make a PR."
+- Keep the pattern consistent enough that organisers can explain the policy in one sentence: send it through the pathway, review it, teach the contributor, merge the useful stuff.
+
+## What we are looking for
+
+- You are comfortable with GitHub pull requests, Markdown, and small content edits.
+- You use coding agents with taste: fast enough to ship, careful enough not to make a mess.
+- You can write clear, compact copy without sanding away the human voice.
+- You are kind in private messages and firm about boundaries.
+- You can tell the difference between a good community post, an under-specified one, and a bad-fit one.
+- You like the idea that every wayward post can become a teaching moment, not just a moderation chore.
+
+## Nice to have
+
+- Familiarity with Astro content collections.
+- Experience helping non-technical people use AI tools without making them feel silly.
+- A feel for Singapore's builder, startup, education, and AI communities.
+- Enough product sense to spot when the workflow itself needs a better template, doc, or tiny automation.
+
+## How success looks
+
+- Events and jobs stop getting lost in chat.
+- Contributors learn how the ABC site works by doing one real contribution.
+- Organisers get a consistent policy instead of a case-by-case debate.
+- The website stays useful, tidy, and reviewable.
+- The community gets more personal interactions at exactly the moments where people are trying to participate.
+
+## How to apply
+
+Email hello@agenticbuilders.sg with the subject line "Events and Jobs Vibe Coder".
+
+Include a short note on:
+
+- one community workflow you have helped keep tidy;
+- one example of using an AI coding tool to make or review a content change;
+- how much time you could realistically give this each week.


### PR DESCRIPTION
## Summary
- Adds a new fractional community job post for an Events and Jobs Vibe Coder.
- Frames the role around routing wayward event/job posts into clean website PRs and contributor teaching moments.
- Uses the existing jobs content collection with ABC as the company and hello@agenticbuilders.sg as the contact.

## Validation
- pnpm check
- pnpm build