### PR TITLE
feat: add dedicated community guidelines page

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -3,5 +3,6 @@ export const navLinks = [
   { href: "/community/", label: "community" },
   { href: "/showcase/", label: "showcase" },
   { href: "/jobs/", label: "jobs" },
-  { href: "/events/", label: "events" }
+  { href: "/events/", label: "events" },
+  { href: "/guidelines/", label: "guidelines" }
 ] as const;

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -21,7 +21,7 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
       We started as "Claude Code Club SG" in September 2025 — a WhatsApp group for Claude Code users in Singapore. As the tool landscape exploded and members adopted Codex, Antigravity, OpenCode, GLM, Kimi, and more, we rebranded to reflect the broader scope.
     </p>
     <p style="margin-top: 12px;">
-      Today we're 400+ <a href="/community/">active members</a> sharing projects, tips, and experiments in a WhatsApp group chat and at monthly meetups around Singapore.
+      Today we're 800+ <a href="/community/">active members</a> sharing projects, tips, and experiments in a WhatsApp group chat and at monthly meetups around Singapore.
     </p>
   </section>
 
@@ -86,19 +86,8 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
 
   <section>
     <h3 class="section-label">Community Guidelines</h3>
-    <div class="list">
-      <div class="list-item">
-        <p>Be polite, respectful, and helpful.</p>
-      </div>
-      <div class="list-item">
-        <p>Keep discussions relevant to agentic coding and building.</p>
-      </div>
-      <div class="list-item">
-        <p>Feel free to share and showcase your personal projects. For commercial work and events, please check by email first.</p>
-      </div>
-      <div class="list-item">
-        <p>Please <a href="https://github.com/agentic-builders-collective/agentic-builders-collective.github.io" target="_blank" rel="noopener">contribute to the website</a>. When doing so, keep changes additive and localised — one content type per PR.</p>
-      </div>
-    </div>
+    <p>
+      We keep the group technical, social, and signal-first. Read the full <a href="/guidelines/" class="muted-link">community guidelines</a> for details on posting events, partnerships, and moderation.
+    </p>
   </section>
 </BaseLayout>

--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -1,0 +1,131 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
+---
+
+<BaseLayout
+  title="guidelines"
+  description="Community guidelines for the Agentic Builders Collective — keeping our space technical, social, and signal-first."
+>
+  <h1 class="page-title">Community Guidelines</h1>
+
+  <section>
+    <p>
+      The WhatsApp group is our living room. The site is our library. Both matter — but the living room has house rules.
+    </p>
+    <p style="margin-top: 12px;">
+      We are 800+ builders exploring agentic coding with Claude Code, Codex, Cursor, Antigravity, and beyond. This space is for technical work, genuine questions, and real connections.
+    </p>
+  </section>
+
+  <section>
+    <h3 class="section-label">Quick Check Before Posting</h3>
+    <div class="list">
+      <div class="list-item">
+        <p>Does this help someone here build better?</p>
+      </div>
+      <div class="list-item">
+        <p>Am I sharing context, not just a link?</p>
+      </div>
+      <div class="list-item">
+        <p>Have I checked in with an admin / PR'd the site?</p>
+      </div>
+    </div>
+    <p style="margin-top: 12px;">If the answer is no, hold off until it is.</p>
+  </section>
+
+  <section>
+    <h3 class="section-label">What We Encourage</h3>
+    <div class="list">
+      <div class="list-item">
+        <p>Technical deep-dives, show-and-tells, and honest "how do I...?" questions</p>
+      </div>
+      <div class="list-item">
+        <p>Sharing projects you're building <em>with</em> agents, not just <em>about</em> AI</p>
+      </div>
+      <div class="list-item">
+        <p>Genuine community — introductions, collaborations, help requests, thoughtful debate</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="section-label">What We Don't Do</h3>
+    <div class="list">
+      <div class="list-item">
+        <p>Drive-by self-promotion (courses, services, "check out my startup" with no context)</p>
+      </div>
+      <div class="list-item">
+        <p>Blatant event or job advertising without community value</p>
+      </div>
+      <div class="list-item">
+        <p>Recruitment spam or affiliate links</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="section-label">Good vs. Blah</h3>
+    <div class="grid columns-2">
+      <div class="person-card" style="border-left: 3px solid rgba(255, 100, 100, 0.5);">
+        <h3>Blah</h3>
+        <p class="person-card-tagline">"Join my AI workshop next week!" <span style="opacity: 0.6;">(link, no context)</span></p>
+      </div>
+      <div class="person-card" style="border-left: 3px solid rgba(100, 255, 150, 0.5);">
+        <h3>Good</h3>
+        <p class="person-card-tagline">"We're running a hands-on agentic coding session — limited to 20, here's the repo with exercises we built. Anyone want to beta test?" <span style="opacity: 0.6;">(context, community value, open invitation)</span></p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="section-label">Sharing Events & Opportunities</h3>
+    <p>Got something relevant? Great. Before posting:</p>
+    <div class="list" style="margin-top: 12px;">
+      <div class="list-item">
+        <p><strong>1. Submit a PR</strong> to our site repo so it's documented for the community</p>
+      </div>
+      <div class="list-item">
+        <p><strong>2. Check in with an admin</strong> so we understand the angle</p>
+      </div>
+      <div class="list-item">
+        <p><strong>3. Post with context</strong> — why this matters to builders here, not just a link and a date</p>
+      </div>
+    </div>
+    <p style="margin-top: 12px;">If it genuinely serves the community, it'll get through. If it's just broadcasting, it won't.</p>
+  </section>
+
+  <section>
+    <h3 class="section-label">Partnerships & Collaborations</h3>
+    <p>
+      We're open to working with organizations that move the space forward — frontier labs, AI-native companies, community builders — as long as the value flows <em>to</em> members, not just <em>from</em> them. Meaningful beats well-connected.
+    </p>
+  </section>
+
+  <section>
+    <h3 class="section-label">Admin Contact</h3>
+    <p>Questions or unsure if something fits? Reach out to any of us:</p>
+    <div class="list" style="margin-top: 12px;">
+      <div class="list-item">
+        <p>Jensen Loke · <a href="mailto:hello@agenticbuilders.sg" class="muted-link" style="font-size: 0.9rem;">hello@agenticbuilders.sg</a></p>
+      </div>
+      <div class="list-item">
+        <p>YJ Soon</p>
+      </div>
+      <div class="list-item">
+        <p>Ian Choo</p>
+      </div>
+      <div class="list-item">
+        <p>Chris Pecaut</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="section-label">Moderation</h3>
+    <p>
+      We moderate lightly but consistently. If something doesn't fit, we'll point you to this page and ask you to reframe. Repeated disregard for the culture is when we remove posts or members. We're not heavy-handed, but we do protect the space.
+    </p>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## What's new

- **New  page** with the full community policy
- **Added to navigation** so it's always one click away
- **Updated ** to link to the new page instead of the brief inline summary

## What's covered

- Quick check before posting (3 questions)
- What we encourage vs. what we don't do
- Good vs. blah posting examples
- Event sharing process (PR → admin check → post with context)
- Partnerships & collaborations policy
- Admin contact list
- Moderation approach

## Why

At 800+ members, having a single canonical guidelines page we can link to saves retyping the policy every time someone asks. It also makes expectations clear upfront.

/cc @jensen-l @yjsoon @ianchoo @chrispecaut for review