### PR TITLE
fix: restructure admin contact section

### DIFF
--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -105,10 +105,15 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
 
   <section>
     <h3 class="section-label">Admin Contact</h3>
-    <p>Questions or unsure if something fits? Reach out to any of us:</p>
+    <p>
+      Reach the whole team: <a href="mailto:hello@agenticbuilders.sg" class="muted-link">hello@agenticbuilders.sg</a>
+    </p>
+    <p style="margin-top: 12px;">
+      Or DM any of us directly in the WhatsApp group:
+    </p>
     <div class="list" style="margin-top: 12px;">
       <div class="list-item">
-        <p>Jensen Loke · <a href="mailto:hello@agenticbuilders.sg" class="muted-link" style="font-size: 0.9rem;">hello@agenticbuilders.sg</a></p>
+        <p>Jensen Loke</p>
       </div>
       <div class="list-item">
         <p>YJ Soon</p>


### PR DESCRIPTION
Restructure the admin contact section to reflect how we actually operate:\n\n- hello@agenticbuilders.sg moved to top as the team email (reaches all admins)\n- Individual admins listed as WhatsApp DM contacts (since everyone is in the group)\n- Removed individual email links\n\n/cc @jensen-l