### PR TITLE
rewrite: community guidelines in founders' voice

### DIFF
--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -29,7 +29,7 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
         <p>Am I sharing context, or just dropping a link?</p>
       </div>
       <div class="list-item">
-        <p>Have I checked in with an admin, or PR'd the site?</p>
+        <p>Have I checked in with an admin, or opened a pull request to the site?</p>
       </div>
     </div>
     <p style="margin-top: 12px;">If the answer to any of those is no, hold off until it is.</p>
@@ -84,7 +84,7 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
     <p>Great — here's how to do it well:</p>
     <div class="list" style="margin-top: 12px;">
       <div class="list-item">
-        <p><strong>1. PR it to the site</strong> so it's documented for everyone</p>
+        <p><strong>1. Open a pull request to the site</strong> so it's documented for everyone (new to GitHub? <a href="https://www.youtube.com/watch?v=s9k-xKiQaQ4" class="muted-link" target="_blank" rel="noopener">here's a walkthrough</a>)</p>
       </div>
       <div class="list-item">
         <p><strong>2. Check in with an admin</strong> so we know the angle</p>

--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -12,12 +12,15 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
 
   <section>
     <p>
-      We're 800+ builders in Singapore exploring agentic coding — Claude Code, Codex, Cursor, Antigravity, and whatever comes next. The WhatsApp group is where we hang out. The site is where we document stuff. Both matter, but the group has house rules.
+      The WhatsApp group is our living room, and the site is our library. Both matter, but the living room has house rules.
+    </p>
+    <p style="margin-top: 12px;">
+      We're 800+ builders in Singapore exploring agentic coding with Claude Code, Codex, Cursor, Antigravity, and whatever comes next. The group works because we keep it technical, social, and signal-first.
     </p>
   </section>
 
   <section>
-    <h3 class="section-label">Before you post, ask yourself:</h3>
+    <h3 class="section-label">Before you post, ask yourself</h3>
     <div class="list">
       <div class="list-item">
         <p>Does this actually help someone here build better?</p>
@@ -26,23 +29,23 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
         <p>Am I sharing context, or just dropping a link?</p>
       </div>
       <div class="list-item">
-        <p>Have I checked with an admin / PR'd the site?</p>
+        <p>Have I checked in with an admin, or PR'd the site?</p>
       </div>
     </div>
-    <p style="margin-top: 12px;">If no to any of the above, hold off.</p>
+    <p style="margin-top: 12px;">If the answer to any of those is no, hold off until it is.</p>
   </section>
 
   <section>
     <h3 class="section-label">What we like seeing</h3>
     <div class="list">
       <div class="list-item">
-        <p>Technical deep-dives, show-and-tells, honest "how do I...?" questions</p>
+        <p>Technical deep-dives, show-and-tells, and honest "how do I...?" questions</p>
       </div>
       <div class="list-item">
         <p>Projects you're building <em>with</em> agents, not just talking <em>about</em> AI</p>
       </div>
       <div class="list-item">
-        <p>Real community — introductions, collaborations, help requests, actual debate</p>
+        <p>Real community stuff — introductions, collaborations, help requests, thoughtful debate</p>
       </div>
     </div>
   </section>
@@ -51,13 +54,13 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
     <h3 class="section-label">What we don't do</h3>
     <div class="list">
       <div class="list-item">
-        <p>Drive-by self-promo (courses, services, "check out my startup" with zero context)</p>
+        <p>Drive-by self-promotion (courses, services, "check out my startup" with no context)</p>
       </div>
       <div class="list-item">
-        <p>Event or job ads that don't serve the community</p>
+        <p>Event or job ads that don't actually serve the community</p>
       </div>
       <div class="list-item">
-        <p>Recruitment spam, affiliate links, anything that smells like noise</p>
+        <p>Recruitment spam or affiliate links, or anything that's basically just noise</p>
       </div>
     </div>
   </section>
@@ -71,63 +74,46 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
       </div>
       <div class="person-card" style="border-left: 3px solid rgba(100, 255, 150, 0.5);">
         <h3>Good</h3>
-        <p class="person-card-tagline">"Running a hands-on agentic coding session — capped at 20, here's the repo with exercises we built. Anyone want to beta test?" <span style="opacity: 0.6;">(context, community value, open invite)</span></p>
+        <p class="person-card-tagline">"We're running a hands-on agentic coding session, limited to 20, and here's the repo with exercises we built. Anyone want to beta test?" <span style="opacity: 0.6;">(context, community value, open invitation)</span></p>
       </div>
     </div>
   </section>
 
   <section>
     <h3 class="section-label">Want to share an event or opportunity?</h3>
-    <p>Cool. Do this first:</p>
+    <p>Great — here's how to do it well:</p>
     <div class="list" style="margin-top: 12px;">
       <div class="list-item">
         <p><strong>1. PR it to the site</strong> so it's documented for everyone</p>
       </div>
       <div class="list-item">
-        <p><strong>2. Check with an admin</strong> so we know what it's about</p>
+        <p><strong>2. Check in with an admin</strong> so we know the angle</p>
       </div>
       <div class="list-item">
-        <p><strong>3. Post with context</strong> — why should builders here care, not just a link and a date</p>
+        <p><strong>3. Post with context</strong>, including why this matters to builders here, not just a link and a date</p>
       </div>
     </div>
-    <p style="margin-top: 12px;">If it genuinely helps the community, it'll fly. If it's just broadcasting, it won't.</p>
+    <p style="margin-top: 12px;">If it genuinely helps the community, it'll get through. If it's just broadcasting, it won't.</p>
   </section>
 
   <section>
     <h3 class="section-label">Partnerships</h3>
     <p>
-      We're open to working with orgs that move the space forward — frontier labs, AI-native companies, community builders. The value needs to flow <em>to</em> our members, not just <em>from</em> us. Meaningful beats well-connected.
+      We're open to working with organisations that move the space forward — frontier labs, AI-native companies, community builders — as long as the value flows <em>to</em> our members, not just <em>from</em> them. Meaningful beats well-connected.
     </p>
   </section>
 
   <section>
     <h3 class="section-label">Admin contact</h3>
     <p>
-      Reach the team: <a href="mailto:hello@agenticbuilders.sg" class="muted-link">hello@agenticbuilders.sg</a>
+      Reach the whole team at <a href="mailto:hello@agenticbuilders.sg" class="muted-link">hello@agenticbuilders.sg</a>, or DM <a href="/community/#jensen-loke" class="muted-link">Jensen Loke</a>, <a href="/community/#yj-soon" class="muted-link">YJ Soon</a>, <a href="/community/#ian-choo" class="muted-link">Ian Choo</a>, or <a href="/community/#chris-pecaut" class="muted-link">Chris Pecaut</a> directly in the WhatsApp group.
     </p>
-    <p style="margin-top: 12px;">
-      Or DM any of us directly in the WhatsApp group:
-    </p>
-    <div class="list" style="margin-top: 12px;">
-      <div class="list-item">
-        <p>Jensen Loke</p>
-      </div>
-      <div class="list-item">
-        <p>YJ Soon</p>
-      </div>
-      <div class="list-item">
-        <p>Ian Choo</p>
-      </div>
-      <div class="list-item">
-        <p>Chris Pecaut</p>
-      </div>
-    </div>
   </section>
 
   <section>
     <h3 class="section-label">Moderation</h3>
     <p>
-      We mod lightly but consistently. If something doesn't fit, we'll point you here and ask you to reframe. Keep ignoring the culture and we'll remove posts or members. Not heavy-handed, but we protect the space.
+      We moderate lightly but consistently. If something doesn't fit, we'll point you here and ask you to reframe. If someone keeps ignoring the culture, that's when we remove posts or members. We're not heavy-handed, but we do protect the space.
     </p>
   </section>
 </BaseLayout>

--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -12,101 +12,98 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
 
   <section>
     <p>
-      The WhatsApp group is our living room. The site is our library. Both matter — but the living room has house rules.
-    </p>
-    <p style="margin-top: 12px;">
-      We are 800+ builders exploring agentic coding with Claude Code, Codex, Cursor, Antigravity, and beyond. This space is for technical work, genuine questions, and real connections.
+      We're 800+ builders in Singapore exploring agentic coding — Claude Code, Codex, Cursor, Antigravity, and whatever comes next. The WhatsApp group is where we hang out. The site is where we document stuff. Both matter, but the group has house rules.
     </p>
   </section>
 
   <section>
-    <h3 class="section-label">Quick Check Before Posting</h3>
+    <h3 class="section-label">Before you post, ask yourself:</h3>
     <div class="list">
       <div class="list-item">
-        <p>Does this help someone here build better?</p>
+        <p>Does this actually help someone here build better?</p>
       </div>
       <div class="list-item">
-        <p>Am I sharing context, not just a link?</p>
+        <p>Am I sharing context, or just dropping a link?</p>
       </div>
       <div class="list-item">
-        <p>Have I checked in with an admin / PR'd the site?</p>
+        <p>Have I checked with an admin / PR'd the site?</p>
       </div>
     </div>
-    <p style="margin-top: 12px;">If the answer is no, hold off until it is.</p>
+    <p style="margin-top: 12px;">If no to any of the above, hold off.</p>
   </section>
 
   <section>
-    <h3 class="section-label">What We Encourage</h3>
+    <h3 class="section-label">What we like seeing</h3>
     <div class="list">
       <div class="list-item">
-        <p>Technical deep-dives, show-and-tells, and honest "how do I...?" questions</p>
+        <p>Technical deep-dives, show-and-tells, honest "how do I...?" questions</p>
       </div>
       <div class="list-item">
-        <p>Sharing projects you're building <em>with</em> agents, not just <em>about</em> AI</p>
+        <p>Projects you're building <em>with</em> agents, not just talking <em>about</em> AI</p>
       </div>
       <div class="list-item">
-        <p>Genuine community — introductions, collaborations, help requests, thoughtful debate</p>
-      </div>
-    </div>
-  </section>
-
-  <section>
-    <h3 class="section-label">What We Don't Do</h3>
-    <div class="list">
-      <div class="list-item">
-        <p>Drive-by self-promotion (courses, services, "check out my startup" with no context)</p>
-      </div>
-      <div class="list-item">
-        <p>Blatant event or job advertising without community value</p>
-      </div>
-      <div class="list-item">
-        <p>Recruitment spam or affiliate links</p>
+        <p>Real community — introductions, collaborations, help requests, actual debate</p>
       </div>
     </div>
   </section>
 
   <section>
-    <h3 class="section-label">Good vs. Blah</h3>
+    <h3 class="section-label">What we don't do</h3>
+    <div class="list">
+      <div class="list-item">
+        <p>Drive-by self-promo (courses, services, "check out my startup" with zero context)</p>
+      </div>
+      <div class="list-item">
+        <p>Event or job ads that don't serve the community</p>
+      </div>
+      <div class="list-item">
+        <p>Recruitment spam, affiliate links, anything that smells like noise</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="section-label">Good vs. meh</h3>
     <div class="grid columns-2">
       <div class="person-card" style="border-left: 3px solid rgba(255, 100, 100, 0.5);">
-        <h3>Blah</h3>
+        <h3>Meh</h3>
         <p class="person-card-tagline">"Join my AI workshop next week!" <span style="opacity: 0.6;">(link, no context)</span></p>
       </div>
       <div class="person-card" style="border-left: 3px solid rgba(100, 255, 150, 0.5);">
         <h3>Good</h3>
-        <p class="person-card-tagline">"We're running a hands-on agentic coding session — limited to 20, here's the repo with exercises we built. Anyone want to beta test?" <span style="opacity: 0.6;">(context, community value, open invitation)</span></p>
+        <p class="person-card-tagline">"Running a hands-on agentic coding session — capped at 20, here's the repo with exercises we built. Anyone want to beta test?" <span style="opacity: 0.6;">(context, community value, open invite)</span></p>
       </div>
     </div>
   </section>
 
   <section>
-    <h3 class="section-label">Sharing Events & Opportunities</h3>
-    <p>Got something relevant? Great. Before posting:</p>
+    <h3 class="section-label">Want to share an event or opportunity?</h3>
+    <p>Cool. Do this first:</p>
     <div class="list" style="margin-top: 12px;">
       <div class="list-item">
-        <p><strong>1. Submit a PR</strong> to our site repo so it's documented for the community</p>
+        <p><strong>1. PR it to the site</strong> so it's documented for everyone</p>
       </div>
       <div class="list-item">
-        <p><strong>2. Check in with an admin</strong> so we understand the angle</p>
+        <p><strong>2. Check with an admin</strong> so we know what it's about</p>
       </div>
       <div class="list-item">
-        <p><strong>3. Post with context</strong> — why this matters to builders here, not just a link and a date</p>
+        <p><strong>3. Post with context</strong> — why should builders here care, not just a link and a date</p>
       </div>
     </div>
-    <p style="margin-top: 12px;">If it genuinely serves the community, it'll get through. If it's just broadcasting, it won't.</p>
+    <p style="margin-top: 12px;">If it genuinely helps the community, it'll fly. If it's just broadcasting, it won't.</p>
   </section>
 
   <section>
-    <h3 class="section-label">Partnerships & Collaborations</h3>
+    <h3 class="section-label">Partnerships</h3>
     <p>
-      We're open to working with organizations that move the space forward — frontier labs, AI-native companies, community builders — as long as the value flows <em>to</em> members, not just <em>from</em> them. Meaningful beats well-connected.
+      We're open to working with orgs that move the space forward — frontier labs, AI-native companies, community builders. The value needs to flow <em>to</em> our members, not just <em>from</em> us. Meaningful beats well-connected.
     </p>
   </section>
 
   <section>
-    <h3 class="section-label">Admin Contact</h3>
+    <h3 class="section-label">Admin contact</h3>
     <p>
-      Reach the whole team: <a href="mailto:hello@agenticbuilders.sg" class="muted-link">hello@agenticbuilders.sg</a>
+      Reach the team: <a href="mailto:hello@agenticbuilders.sg" class="muted-link">hello@agenticbuilders.sg</a>
     </p>
     <p style="margin-top: 12px;">
       Or DM any of us directly in the WhatsApp group:
@@ -130,7 +127,7 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
   <section>
     <h3 class="section-label">Moderation</h3>
     <p>
-      We moderate lightly but consistently. If something doesn't fit, we'll point you to this page and ask you to reframe. Repeated disregard for the culture is when we remove posts or members. We're not heavy-handed, but we do protect the space.
+      We mod lightly but consistently. If something doesn't fit, we'll point you here and ask you to reframe. Keep ignoring the culture and we'll remove posts or members. Not heavy-handed, but we protect the space.
     </p>
   </section>
 </BaseLayout>


### PR DESCRIPTION
Rewrote the community guidelines to sound less like a corporate policy doc and more like how we actually talk.

Changes:
- Shorter, punchier sentences
- 'What we like seeing' / 'What we don't do' instead of formal encourage/don't categories
- 'Meh' vs 'Good' with honest framing
- 'We mod lightly but consistently' instead of verbose moderation section
- Removed filler like 'This space is for...' and 'Genuine community'

Jensen to review and approve manually.

/cc @jensen-l @yjsoon @ianchoo @chrispecaut