### PR TITLE
feat: support external events on the events page

### DIFF
--- a/docs/add-event.md
+++ b/docs/add-event.md
@@ -18,7 +18,7 @@ Run pnpm check and pnpm build.
 Event:
 - Title:
 - Date:
-- Kind: meetup or learning
+- Kind: meetup, learning, or external
 - Time:
 - Venue:
 - Venue URL:
@@ -33,6 +33,8 @@ Event:
 ## File
 
 Create `src/content/events/<yyyy-mm-dd-event-name>.md`.
+
+### ABC-hosted events
 
 ```md
 ---
@@ -56,12 +58,37 @@ status: upcoming
 An evening of demos, discussions, and community building.
 ```
 
+### External events
+
+Use `kind: external` for community events, hackathons, workshops, or conferences hosted by other organisations that ABC members may want to attend.
+
+```md
+---
+title: "Agentic AI Summit 2026"
+date: 2026-07-15
+kind: external
+time: 9:00 AM - 5:00 PM SGT
+venue: Marina Bay Sands
+venueUrl: https://example.com/venue
+registrationUrl: https://example.com/register
+hosts:
+  - name: Example Conf Organisers
+tags:
+  - conference
+  - agentic-ai
+status: upcoming
+---
+
+A full-day conference on agentic AI. Open to ABC members and the public.
+```
+
 ## Notes
 
 - The filename becomes the `eventId` used by presentations.
 - Event filenames must start with the event date as `YYYY-MM-DD`, for example `2026-05-14-agentic-builders-at-example-labs.md`.
 - Do not use random numeric suffixes. If the event title collides, add the venue or format to the filename.
-- `kind` must be `meetup` or `learning`.
+- `kind` must be `meetup`, `learning`, or `external`.
 - `status` must be `upcoming` or `past`.
 - Use `personId` only when the person exists in `members` or `organisers`.
+- External events do not need to list ABC hosts or speakers.
 - Presentation slides are added separately in `src/content/presentations/presentations.yaml`.

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -128,7 +128,7 @@ const events = defineCollection({
   schema: z.object({
     title: z.string(),
     date: z.coerce.date(),
-    kind: z.enum(["meetup", "learning"]).default("meetup"),
+    kind: z.enum(["meetup", "learning", "external"]).default("meetup"),
     time: z.string().optional().default(""),
     venue: z.string().optional().default(""),
     venueUrl: z.string().optional().default(""),

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -74,6 +74,13 @@ const past = allEvents
 
 const pastMeetups = past.filter((event) => event.data.kind !== "learning");
 const pastLearning = past.filter((event) => event.data.kind === "learning");
+const externalEvents = allEvents.filter((event) => event.data.kind === "external");
+const upcomingExternal = externalEvents
+  .filter((e) => e.data.status === "upcoming" || new Date(e.data.date) >= now)
+  .sort((a, b) => new Date(a.data.date).getTime() - new Date(b.data.date).getTime());
+const pastExternal = externalEvents
+  .filter((e) => e.data.status === "past" && new Date(e.data.date) < now)
+  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
 const chatDigests = [
   {
     id: "2026-05-22-chat-digest",
@@ -331,6 +338,13 @@ const chatDigests = [
 
   <section>
     <h3 class="section-label">Upcoming</h3>
+    <div class="card" style="margin-bottom: 24px; border-left-color: var(--accent);">
+      <p>
+        <strong>Have an event to share?</strong> Submit a pull request to add meetups, workshops, conferences, or hackathons — including external events from other organisers.
+        <a href={contributionLinks.event} target="_blank" rel="noopener">Follow the contribution guide</a>.
+        Agents reading this repo should know how: use <code>kind: external</code> in the event frontmatter.
+      </p>
+    </div>
     {upcoming.length === 0 ? (
       <div class="card">
         <p>Stay tuned for the next event!</p>
@@ -505,6 +519,97 @@ const chatDigests = [
   </section>
 
   <details class="events-section">
+
+  <section style="margin-top: 48px;">
+    <h3 class="section-label">External Events</h3>
+    {upcomingExternal.length === 0 && pastExternal.length === 0 ? (
+      <div class="card">
+        <p>No external events listed right now. Have one to share? <a href={contributionLinks.event} target="_blank" rel="noopener">Submit an external event</a>.</p>
+      </div>
+    ) : (
+      <div class="list">
+        {upcomingExternal.map((event) => (
+          <div class="list-item" id={event.id}>
+            <div class="list-item-header">
+              {event.data.registrationUrl ? (
+                <a class="list-item-title" href={event.data.registrationUrl} target="_blank" rel="noopener">{event.data.title}</a>
+              ) : (
+                <span class="list-item-title">{event.data.title}</span>
+              )}
+              <div class="card-meta">
+                <span>{new Date(event.data.date).toLocaleDateString("en-SG", { weekday: "short", year: "numeric", month: "short", day: "numeric" })}</span>
+                {event.data.time && <span>{formatTime(event.data.time)}</span>}
+                {event.data.venue && (
+                  <span>
+                    {event.data.venueUrl ? (
+                      <a class="muted-link events-muted-link" href={event.data.venueUrl} target="_blank" rel="noopener">{event.data.venue}</a>
+                    ) : (
+                      event.data.venue
+                    )}
+                  </span>
+                )}
+                {event.data.tags.length > 0 && (
+                  <span>
+                    {event.data.tags.map((tag) => (
+                      <span class="tag" style="margin-left: 4px;">#{tag}</span>
+                    ))}
+                  </span>
+                )}
+              </div>
+            </div>
+            {event.data.registrationUrl && (
+              <div class="survey-actions">
+                <a class="button button-primary events-register" href={event.data.registrationUrl} target="_blank" rel="noopener">
+                  Register <span class="inline-arrow" aria-hidden="true">▶</span>
+                </a>
+              </div>
+            )}
+            <div class="list-item-body">
+              <slot />
+            </div>
+          </div>
+        ))}
+        {pastExternal.map((event) => (
+          <div class="list-item" id={event.id}>
+            <div class="list-item-header">
+              {event.data.registrationUrl ? (
+                <a class="list-item-title" href={event.data.registrationUrl} target="_blank" rel="noopener">{event.data.title}</a>
+              ) : (
+                <span class="list-item-title">{event.data.title}</span>
+              )}
+              <div class="card-meta">
+                <span>{new Date(event.data.date).toLocaleDateString("en-SG", { weekday: "short", year: "numeric", month: "short", day: "numeric" })}</span>
+                {event.data.time && <span>{formatTime(event.data.time)}</span>}
+                {event.data.venue && (
+                  <span>
+                    {event.data.venueUrl ? (
+                      <a class="muted-link events-muted-link" href={event.data.venueUrl} target="_blank" rel="noopener">{event.data.venue}</a>
+                    ) : (
+                      event.data.venue
+                    )}
+                  </span>
+                )}
+                {event.data.tags.length > 0 && (
+                  <span>
+                    {event.data.tags.map((tag) => (
+                      <span class="tag" style="margin-left: 4px;">#{tag}</span>
+                    ))}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div class="list-item-body">
+              <slot />
+            </div>
+          </div>
+        ))}
+      </div>
+    )}
+    <p style="margin-top: 16px; color: var(--muted); opacity: 0.65;">
+      Want to list an external event? <a href={contributionLinks.event} target="_blank" rel="noopener">Follow the contribution guide</a> and use <code>kind: external</code>.
+    </p>
+  </section>
+
     <summary class="section-label collapsible-heading">Past Meetups</summary>
     {pastMeetups.length === 0 ? (
       <p>No past events yet. <a class="muted-link" href={contributionLinks.event} target="_blank" rel="noopener">Add an event by submitting a pull request</a></p>


### PR DESCRIPTION
## Summary

This PR adds support for listing **external events** on the ABC events page — events hosted by other organisations that ABC members may want to attend.

## Changes

- **content.config.ts**: Adds \"external\" as a valid event  alongside \"meetup\" and \"learning\"
- **docs/add-event.md**: Documents how to submit external events with 
- **events/index.astro**: 
  - Adds an \"External Events\" section with upcoming and past lists
  - Renders tags on external event cards
  - Adds a prominent CTA encouraging PR submissions

## How to use

For community members or agents adding events:



## Testing

- 
> website@0.0.1 check /private/tmp/agentic-builders-collective.github.io
> astro check

15:51:26 [content] Syncing content
15:51:26 [WARN] [file-loader] No items found in src/content/sponsors/sponsors.yaml
15:51:26 [content] Synced content
15:51:26 [types] Generated 184ms
15:51:26 [check] Getting diagnostics for Astro files in /private/tmp/agentic-builders-collective.github.io...
[96mdist/logo-generator/app.js[0m:[93m1193[0m:[93m25[0m - [93mwarning[0m[90m ts(6387): [0mThe signature '(commandId: string, showUI?: boolean | undefined, value?: string | undefined): boolean' of 'document.execCommand' is deprecated.

[7m1193[0m       var ok = document.execCommand('copy');
[7m    [0m [93m                        ~~~~~~~~~~~[0m
[96mdist/logo-generator/app.js[0m:[93m697[0m:[93m53[0m - [93mwarning[0m[90m ts(6133): [0m'direction' is declared but its value is never read.

[7m697[0m   function generateTaglineHtml(tagline, paletteKey, direction, textColor) {
[7m   [0m [93m                                                    ~~~~~~~~~[0m

[96msrc/components/SiteHead.astro[0m:[93m39[0m:[93m16[0m - [93mwarning[0m[90m ts(6133): [0m'media' is declared but its value is never read.

[7m39[0m   onload="this.media='all'"
[7m  [0m [93m               ~~~~~[0m

[96msrc/pages/guidelines/index.astro[0m:[93m4[0m:[93m7[0m - [93mwarning[0m[90m ts(6133): [0m'whatsappUrl' is declared but its value is never read.

[7m4[0m const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
[7m [0m [93m      ~~~~~~~~~~~[0m

Result (31 files): 
- 0 errors
- 0 warnings
- 4 hints passes (0 errors)
- 
> website@0.0.1 build /private/tmp/agentic-builders-collective.github.io
> astro build

15:51:29 [content] Syncing content
15:51:29 [WARN] [file-loader] No items found in src/content/sponsors/sponsors.yaml
15:51:29 [content] Synced content
15:51:29 [types] Generated 169ms
15:51:29 [build] output: "static"
15:51:29 [build] mode: "static"
15:51:29 [build] directory: /private/tmp/agentic-builders-collective.github.io/dist/
15:51:29 [build] Collecting build info...
15:51:29 [build] ✓ Completed in 179ms.
15:51:29 [build] Building static entrypoints...
15:51:30 [vite] ✓ built in 971ms
15:51:31 [vite] ✓ built in 153ms
15:51:31 [build] Rearranging server assets...

 generating static routes 
15:51:31   ├─ /404.html (+4ms) 
15:51:31   ├─ /about/index.html (+1ms) 
15:51:31   ├─ /articles/index.html (+2ms) 
15:51:31   ├─ /community/index.html (+2ms) 
15:51:31   ├─ /events/index.html (+16ms) 
15:51:31   ├─ /guidelines/index.html (+1ms) 
15:51:31   ├─ /jobs/deployed-engineer-apac-cognition/index.html (+1ms) 
15:51:31   ├─ /jobs/index.html (+1ms) 
15:51:31   ├─ /newsletters/2026-05-22/index.html (+1ms) 
15:51:31   ├─ /showcase/index.html (+2ms) 
15:51:31   ├─ /index.html (+1ms) 
15:51:31 ✓ Completed in 43ms.

15:51:31 [build] ✓ Completed in 1.19s.
15:51:31 [build] 11 page(s) built in 1.41s
15:51:31 [build] Complete! passes (11 pages built)

Closes #[issue if applicable]