### PR TITLE
fix: use proper tag-list markup for external events

### DIFF
--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -548,13 +548,6 @@ const chatDigests = [
                     )}
                   </span>
                 )}
-                {event.data.tags.length > 0 && (
-                  <span>
-                    {event.data.tags.map((tag) => (
-                      <span class="tag" style="margin-left: 4px;">#{tag}</span>
-                    ))}
-                  </span>
-                )}
               </div>
             </div>
             {event.data.registrationUrl && (
@@ -563,6 +556,13 @@ const chatDigests = [
                   Register <span class="inline-arrow" aria-hidden="true">▶</span>
                 </a>
               </div>
+            )}
+            {event.data.tags.length > 0 && (
+              <ul class="tag-list" style="margin-top: 8px;">
+                {event.data.tags.map((tag) => (
+                  <li class="tag">{tag}</li>
+                ))}
+              </ul>
             )}
             <div class="list-item-body">
               <slot />
@@ -589,15 +589,15 @@ const chatDigests = [
                     )}
                   </span>
                 )}
-                {event.data.tags.length > 0 && (
-                  <span>
-                    {event.data.tags.map((tag) => (
-                      <span class="tag" style="margin-left: 4px;">#{tag}</span>
-                    ))}
-                  </span>
-                )}
               </div>
             </div>
+            {event.data.tags.length > 0 && (
+              <ul class="tag-list" style="margin-top: 8px;">
+                {event.data.tags.map((tag) => (
+                  <li class="tag">{tag}</li>
+                ))}
+              </ul>
+            )}
             <div class="list-item-body">
               <slot />
             </div>


### PR DESCRIPTION
## Problem

The previous PR used inline `<span>` elements with manual `#` prefixes for tags on external events. This bypasses the site's CSS `.tag::before` rule and won't render consistently with the rest of the site.

## Fix

Replace inline spans with proper `<ul class="tag-list">` + `<li class="tag">` markup, matching the pattern used on showcase and articles pages. The CSS `.tag::before { content: "#"; }` now handles the prefix automatically.

## Testing

- `pnpm check` passes (0 errors)
- `pnpm build` passes (11 pages built)
