### PR TITLE
Show shared-by member links on events

### DIFF
--- a/docs/add-event.md
+++ b/docs/add-event.md
@@ -25,6 +25,7 @@ Event:
 - Registration URL:
 - Hosts:
 - Speakers:
+- Shared by:
 - Tags:
 - Status: upcoming or past
 - Description:
@@ -73,6 +74,8 @@ venueUrl: https://example.com/venue
 registrationUrl: https://example.com/register
 hosts:
   - name: Example Conf Organisers
+sharedBy:
+  - personId: jane-doe
 tags:
   - conference
   - agentic-ai
@@ -91,4 +94,5 @@ A full-day conference on agentic AI. Open to ABC members and the public.
 - `status` must be `upcoming` or `past`.
 - Use `personId` only when the person exists in `members` or `organisers`.
 - External events do not need to list ABC hosts or speakers.
+- Use `sharedBy` when a listed member or organiser surfaced the event for the community.
 - Presentation slides are added separately in `src/content/presentations/presentations.yaml`.

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -144,6 +144,8 @@ registrationUrl: https://example.com/register
 hosts:
   - personId: jane-doe
   - name: External Host
+sharedBy:
+  - personId: jane-doe
 tags:
   - meetup
 status: upcoming
@@ -151,6 +153,8 @@ status: upcoming
 
 An evening of demos, discussions, and community building.
 ```
+
+Use `sharedBy` when a listed member or organiser contributed the event listing or surfaced an external opportunity for the community.
 
 #### Event surveys
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -138,6 +138,7 @@ const events = defineCollection({
     attendance: z.number().optional().default(0),
     speakers: legacyPersonRefs,
     hosts: legacyPersonRefs,
+    sharedBy: legacyPersonRefs,
     tags: z.array(z.string()).default([]),
     status: z.enum(["upcoming", "past"]).default("past"),
     preEventSurvey: z.object({

--- a/src/content/events/2026-08-18-build-with-gemini-xprize.md
+++ b/src/content/events/2026-08-18-build-with-gemini-xprize.md
@@ -2,19 +2,20 @@
 title: "Build with Gemini XPRIZE"
 date: 2026-08-18
 kind: "learning"
-time: "Submissions close 4:00 AM SGT"
+time: "Submissions end on August 18th"
 venue: "Online"
 venueUrl: "https://www.geminixprize.com/"
 registrationUrl: "https://www.geminixprize.com/"
 attendance: 0
 speakers: []
-hosts:
+hosts: []
+sharedBy:
   - personId: shiyan-koh
 tags: ["hackathon", "gemini", "building-session"]
 status: "upcoming"
 ---
 Shiyan Koh shared the Build with Gemini XPRIZE with the community and suggested that ABC members could team up and hold a joint building session around it.
 
-The challenge gives builders 90 days to create a real AI-operated business using Gemini and at least one Google Cloud product, with $2M in prizes across 25 winners. Teams are expected to ship a working product, get real users, show revenue evidence, and submit by the official deadline: Aug 17, 2026 at 1:00 PM PT / Aug 18, 2026 at 4:00 AM SGT.
+The challenge gives builders 90 days to create a real AI-operated business using Gemini and at least one Google Cloud product, with $2M in prizes across 25 winners. Teams are expected to ship a working product, get real users, show revenue evidence, and submit before submissions end on August 18th.
 
 Use this as a coordination point if you want to find collaborators, pick a category, and build together before submissions close.

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -3,11 +3,14 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import QRCode from "../../components/QRCode.astro";
 import { getCollection } from "astro:content";
 import { contributionLinks } from "../../lib/contribution-links";
-import { buildEventIndex, getLinkedEvent } from "../../lib/relations";
+import { buildEventIndex, buildPeopleIndex, getLinkedEvent, resolvePersonRefs } from "../../lib/relations";
 import { recaps } from "../../lib/recaps";
 
 const allEvents = await getCollection("events");
 const allPresentations = await getCollection("presentations");
+const allMembers = await getCollection("members");
+const organisers = await getCollection("organisers");
+const peopleById = buildPeopleIndex([...organisers, ...allMembers]);
 const eventsById = buildEventIndex(allEvents);
 const presentationsByEventId = new Map<string, typeof allPresentations>();
 for (const presentation of allPresentations) {
@@ -24,6 +27,11 @@ for (const [, presentations] of presentationsByEventId) {
 }
 
 const getEventPresentations = (eventId: string) => presentationsByEventId.get(eventId) ?? [];
+const getSharedBy = (event: typeof allEvents[number]) => resolvePersonRefs(
+  event.data.sharedBy,
+  peopleById,
+  `event "${event.id}" sharedBy`,
+);
 const now = new Date();
 const getEventHref = (eventId: string) => `/events/#${eventId}`;
 const formatTime = (time: string) => time.replace(/\s*SGT$/, "");
@@ -372,6 +380,7 @@ const chatDigests = [
               const closesInsideSurvey = closesText && preSurvey?.url && preSurvey.closesAtPlacement === "inside";
               const closesOutsideSurvey = closesText && preSurvey?.url && preSurvey.closesAtPlacement === "outside";
               const hasResults = hasFeedbackResults(event.data.feedback);
+              const sharedBy = getSharedBy(event);
               return (
                 <>
                   <div class="list-item-header">
@@ -390,6 +399,21 @@ const chatDigests = [
                             <>
                               {" + "}
                               <a class="muted-link events-muted-link" href={sponsor.url} target="_blank" rel="noopener">{sponsor.name}</a>
+                            </>
+                          ))}
+                        </span>
+                      )}
+                      {sharedBy.length > 0 && (
+                        <span>
+                          Shared by{" "}
+                          {sharedBy.map((person, index) => (
+                            <>
+                              {person.href ? (
+                                <a class="muted-link events-muted-link" href={person.href}>{person.name}</a>
+                              ) : (
+                                person.name
+                              )}
+                              {index < sharedBy.length - 1 && ", "}
                             </>
                           ))}
                         </span>
@@ -413,9 +437,6 @@ const chatDigests = [
                         Register <span class="inline-arrow" aria-hidden="true">▶</span>
                       </a>
                     )}
-                    <a class="button button-secondary" href={getEventHref(event.id)} aria-label={`Link to ${event.data.title}`}>
-                      Event link
-                    </a>
                     {preSurvey?.url && (
                       <a class="button button-secondary events-survey-button" href={preSurvey.url} target="_blank" rel="noopener">
                         <span>{preSurvey.takeSurveyLabel || "Take survey"}</span>
@@ -551,6 +572,21 @@ const chatDigests = [
                     )}
                   </span>
                 )}
+                {getSharedBy(event).length > 0 && (
+                  <span>
+                    Shared by{" "}
+                    {getSharedBy(event).map((person, index) => (
+                      <>
+                        {person.href ? (
+                          <a class="muted-link events-muted-link" href={person.href}>{person.name}</a>
+                        ) : (
+                          person.name
+                        )}
+                        {index < getSharedBy(event).length - 1 && ", "}
+                      </>
+                    ))}
+                  </span>
+                )}
               </div>
             </div>
             <div class="survey-actions">
@@ -559,9 +595,6 @@ const chatDigests = [
                   Register <span class="inline-arrow" aria-hidden="true">▶</span>
                 </a>
               )}
-              <a class="button button-secondary" href={getEventHref(event.id)} aria-label={`Link to ${event.data.title}`}>
-                Event link
-              </a>
             </div>
             {event.data.tags.length > 0 && (
               <ul class="tag-list" style="margin-top: 8px;">
@@ -589,6 +622,21 @@ const chatDigests = [
                     ) : (
                       event.data.venue
                     )}
+                  </span>
+                )}
+                {getSharedBy(event).length > 0 && (
+                  <span>
+                    Shared by{" "}
+                    {getSharedBy(event).map((person, index) => (
+                      <>
+                        {person.href ? (
+                          <a class="muted-link events-muted-link" href={person.href}>{person.name}</a>
+                        ) : (
+                          person.name
+                        )}
+                        {index < getSharedBy(event).length - 1 && ", "}
+                      </>
+                    ))}
                   </span>
                 )}
               </div>
@@ -635,6 +683,21 @@ const chatDigests = [
                       <>
                         {" + "}
                         <a class="muted-link events-muted-link" href={sponsor.url} target="_blank" rel="noopener">{sponsor.name}</a>
+                      </>
+                    ))}
+                  </span>
+                )}
+                {getSharedBy(event).length > 0 && (
+                  <span>
+                    Shared by{" "}
+                    {getSharedBy(event).map((person, index) => (
+                      <>
+                        {person.href ? (
+                          <a class="muted-link events-muted-link" href={person.href}>{person.name}</a>
+                        ) : (
+                          person.name
+                        )}
+                        {index < getSharedBy(event).length - 1 && ", "}
                       </>
                     ))}
                   </span>
@@ -794,6 +857,21 @@ const chatDigests = [
                       <>
                         {" + "}
                         <a class="muted-link events-muted-link" href={sponsor.url} target="_blank" rel="noopener">{sponsor.name}</a>
+                      </>
+                    ))}
+                  </span>
+                )}
+                {getSharedBy(event).length > 0 && (
+                  <span>
+                    Shared by{" "}
+                    {getSharedBy(event).map((person, index) => (
+                      <>
+                        {person.href ? (
+                          <a class="muted-link events-muted-link" href={person.href}>{person.name}</a>
+                        ) : (
+                          person.name
+                        )}
+                        {index < getSharedBy(event).length - 1 && ", "}
                       </>
                     ))}
                   </span>


### PR DESCRIPTION
## Summary
- Add optional event sharedBy metadata and document it for future event submissions.
- Show shared-by people in event metadata with member profile links.
- Update the Gemini XPRIZE event to show Shared by Shiyan Koh, remove the extra Event link button, and use Submissions end on August 18th without the 4:00 AM detail.

## Verification
- pnpm check
- pnpm build
- Browser-verified /events/#2026-08-18-build-with-gemini-xprize shows Shared by Shiyan Koh linked to /community/#shiyan-koh, no Event link button, and no 4:00 AM text.