### PR TITLE
Add APAC Disaster Relief Builder Lab event

### DIFF
--- a/src/content/events/2026-06-11-apac-disaster-relief-builder-lab.md
+++ b/src/content/events/2026-06-11-apac-disaster-relief-builder-lab.md
@@ -1,0 +1,26 @@
+---
+title: "APAC Disaster Relief Phase 2 Builder Lab"
+date: 2026-06-11
+kind: "external"
+time: "June 11-12, 2026"
+venue: "Sofitel Bangkok Sukhumvit"
+venueUrl: "https://maps.google.com/?q=Sofitel+Bangkok+Sukhumvit"
+registrationUrl: "https://forms.gle/x2D1YkWX5vk7z8c27"
+attendance: 0
+speakers: []
+hosts:
+  - name: "DataKind"
+  - name: "OpenAI"
+  - name: "ADPC"
+  - name: "Gates Foundation"
+tags: ["builder-lab", "disaster-relief", "codex", "public-good"]
+status: "upcoming"
+---
+Hello ABC,
+DataKind, in partnership with OpenAI, ADPC, and Gates Foundation, is recruiting technical builders for a two-day Builder Lab in Bangkok on 11-12 June.
+
+Builders will work alongside disaster-management representatives from 13 Asian governments, using OpenAI Codex to prototype practical AI workflows for disaster response. Example workflows include AI-assisted situation reporting, flood-data analysis and summarization dashboards, and tools that convert field notes or WhatsApp-style updates into structured information for human review.
+
+The goal is to help disaster-response teams turn incoming information into trusted analysis and decision-ready reports more quickly, so they can respond more effectively to communities affected by natural disasters.
+
+This is an exciting opportunity to apply AI for the public good! Learn more and submit interest by 29 May: https://forms.gle/x2D1YkWX5vk7z8c27


### PR DESCRIPTION
## Summary
Adds an external event listing for the APAC Disaster Relief Phase 2 Builder Lab in Bangkok on 11-12 June 2026.

## Notes
This listing points interested technical builders to the DataKind-managed application form.

## Validation
Created through GitHub web editor.