### PR TITLE
fix: link markjason maker to gijs-verheijke member

### DIFF
--- a/src/content/projects/markjason.md
+++ b/src/content/projects/markjason.md
@@ -1,7 +1,7 @@
 ---
 title: markjason
 makers:
-  - name: Gijs Verheijke
+  - personId: gijs-verheijke
 url: https://markjason.app
 github: https://github.com/gijsverheijke/markjason
 screenshot: /images/showcase/markjason.png


### PR DESCRIPTION
## Summary
- Update `src/content/projects/markjason.md` to use `personId: gijs-verheijke` instead of bare `name: Gijs Verheijke`.
- Now that Gijs is a member (added via #43), the markjason project (#44) can link to his community profile, matching the convention used by `datadeck.md` and `pg-ffmpeg.md`.
- Couldn't push to #44's fork branch directly (scope-locked), so doing it as a tiny follow-up.

## Test plan
- [x] `pnpm check` passes (0 errors)
- [ ] Verify the project card on /projects/ links the maker to /community/#gijs-verheijke

🤖 Generated with [Claude Code](https://claude.com/claude-code)