### PR TITLE
rewrite: community guidelines voice pass

### DIFF
--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -12,125 +12,108 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
 
   <section>
     <p>
-      The WhatsApp group is our living room. The site is our library. Both matter — but the living room has house rules.
+      The WhatsApp group is our living room, and the site is our library. Both matter, but the living room has house rules.
     </p>
     <p style="margin-top: 12px;">
-      We are 800+ builders exploring agentic coding with Claude Code, Codex, Cursor, Antigravity, and beyond. This space is for technical work, genuine questions, and real connections.
+      We're 800+ builders in Singapore exploring agentic coding with Claude Code, Codex, Cursor, Antigravity, and whatever comes next. The group works because we keep it technical, social, and signal-first.
     </p>
   </section>
 
   <section>
-    <h3 class="section-label">Quick Check Before Posting</h3>
+    <h3 class="section-label">Before you post, ask yourself</h3>
     <div class="list">
       <div class="list-item">
-        <p>Does this help someone here build better?</p>
+        <p>Does this actually help someone here build better?</p>
       </div>
       <div class="list-item">
-        <p>Am I sharing context, not just a link?</p>
+        <p>Am I sharing context, or just dropping a link?</p>
       </div>
       <div class="list-item">
-        <p>Have I checked in with an admin / PR'd the site?</p>
+        <p>Have I checked in with an admin, or PR'd the site?</p>
       </div>
     </div>
-    <p style="margin-top: 12px;">If the answer is no, hold off until it is.</p>
+    <p style="margin-top: 12px;">If the answer to any of those is no, hold off until it is.</p>
   </section>
 
   <section>
-    <h3 class="section-label">What We Encourage</h3>
+    <h3 class="section-label">What we like seeing</h3>
     <div class="list">
       <div class="list-item">
         <p>Technical deep-dives, show-and-tells, and honest "how do I...?" questions</p>
       </div>
       <div class="list-item">
-        <p>Sharing projects you're building <em>with</em> agents, not just <em>about</em> AI</p>
+        <p>Projects you're building <em>with</em> agents, not just talking <em>about</em> AI</p>
       </div>
       <div class="list-item">
-        <p>Genuine community — introductions, collaborations, help requests, thoughtful debate</p>
+        <p>Real community stuff — introductions, collaborations, help requests, thoughtful debate</p>
       </div>
     </div>
   </section>
 
   <section>
-    <h3 class="section-label">What We Don't Do</h3>
+    <h3 class="section-label">What we don't do</h3>
     <div class="list">
       <div class="list-item">
         <p>Drive-by self-promotion (courses, services, "check out my startup" with no context)</p>
       </div>
       <div class="list-item">
-        <p>Blatant event or job advertising without community value</p>
+        <p>Event or job ads that don't actually serve the community</p>
       </div>
       <div class="list-item">
-        <p>Recruitment spam or affiliate links</p>
+        <p>Recruitment spam or affiliate links, or anything that's basically just noise</p>
       </div>
     </div>
   </section>
 
   <section>
-    <h3 class="section-label">Good vs. Blah</h3>
+    <h3 class="section-label">Good vs. meh</h3>
     <div class="grid columns-2">
       <div class="person-card" style="border-left: 3px solid rgba(255, 100, 100, 0.5);">
-        <h3>Blah</h3>
+        <h3>Meh</h3>
         <p class="person-card-tagline">"Join my AI workshop next week!" <span style="opacity: 0.6;">(link, no context)</span></p>
       </div>
       <div class="person-card" style="border-left: 3px solid rgba(100, 255, 150, 0.5);">
         <h3>Good</h3>
-        <p class="person-card-tagline">"We're running a hands-on agentic coding session — limited to 20, here's the repo with exercises we built. Anyone want to beta test?" <span style="opacity: 0.6;">(context, community value, open invitation)</span></p>
+        <p class="person-card-tagline">"We're running a hands-on agentic coding session, limited to 20, and here's the repo with exercises we built. Anyone want to beta test?" <span style="opacity: 0.6;">(context, community value, open invitation)</span></p>
       </div>
     </div>
   </section>
 
   <section>
-    <h3 class="section-label">Sharing Events & Opportunities</h3>
-    <p>Got something relevant? Great. Before posting:</p>
+    <h3 class="section-label">Want to share an event or opportunity?</h3>
+    <p>Great — here's how to do it well:</p>
     <div class="list" style="margin-top: 12px;">
       <div class="list-item">
-        <p><strong>1. Submit a PR</strong> to our site repo so it's documented for the community</p>
+        <p><strong>1. PR it to the site</strong> so it's documented for everyone</p>
       </div>
       <div class="list-item">
-        <p><strong>2. Check in with an admin</strong> so we understand the angle</p>
+        <p><strong>2. Check in with an admin</strong> so we know the angle</p>
       </div>
       <div class="list-item">
-        <p><strong>3. Post with context</strong> — why this matters to builders here, not just a link and a date</p>
+        <p><strong>3. Post with context</strong>, including why this matters to builders here, not just a link and a date</p>
       </div>
     </div>
-    <p style="margin-top: 12px;">If it genuinely serves the community, it'll get through. If it's just broadcasting, it won't.</p>
+    <p style="margin-top: 12px;">If it genuinely helps the community, it'll get through. If it's just broadcasting, it won't.</p>
   </section>
 
   <section>
-    <h3 class="section-label">Partnerships & Collaborations</h3>
+    <h3 class="section-label">Partnerships</h3>
     <p>
-      We're open to working with organizations that move the space forward — frontier labs, AI-native companies, community builders — as long as the value flows <em>to</em> members, not just <em>from</em> them. Meaningful beats well-connected.
+      We're open to working with organisations that move the space forward — frontier labs, AI-native companies, community builders — as long as the value flows <em>to</em> our members, not just <em>from</em> them. Meaningful beats well-connected.
     </p>
   </section>
 
   <section>
-    <h3 class="section-label">Admin Contact</h3>
+    <h3 class="section-label">Admin contact</h3>
     <p>
-      Reach the whole team: <a href="mailto:hello@agenticbuilders.sg" class="muted-link">hello@agenticbuilders.sg</a>
+      Reach the whole team at <a href="mailto:hello@agenticbuilders.sg" class="muted-link">hello@agenticbuilders.sg</a>, or DM <a href="/community/#jensen-loke" class="muted-link">Jensen Loke</a>, <a href="/community/#yj-soon" class="muted-link">YJ Soon</a>, <a href="/community/#ian-choo" class="muted-link">Ian Choo</a>, or <a href="/community/#chris-pecaut" class="muted-link">Chris Pecaut</a> directly in the WhatsApp group.
     </p>
-    <p style="margin-top: 12px;">
-      Or DM any of us directly in the WhatsApp group:
-    </p>
-    <div class="list" style="margin-top: 12px;">
-      <div class="list-item">
-        <p>Jensen Loke</p>
-      </div>
-      <div class="list-item">
-        <p>YJ Soon</p>
-      </div>
-      <div class="list-item">
-        <p>Ian Choo</p>
-      </div>
-      <div class="list-item">
-        <p>Chris Pecaut</p>
-      </div>
-    </div>
   </section>
 
   <section>
     <h3 class="section-label">Moderation</h3>
     <p>
-      We moderate lightly but consistently. If something doesn't fit, we'll point you to this page and ask you to reframe. Repeated disregard for the culture is when we remove posts or members. We're not heavy-handed, but we do protect the space.
+      We moderate lightly but consistently. If something doesn't fit, we'll point you here and ask you to reframe. If someone keeps ignoring the culture, that's when we remove posts or members. We're not heavy-handed, but we do protect the space.
     </p>
   </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary
Reworks the community guidelines copy to sound more like how we actually talk, building on the direction in #41 but tuned against YJ's voice file (long flowing sentences over clipped fragments, contractions throughout, British spelling, em dashes used sparingly).

Key differences from main:
- Restores and lightly tweaks the "living room / library" metaphor.
- Sentence-case headings throughout (`What we like seeing`, `Want to share an event or opportunity?`, etc.).
- Adds "in Singapore" to the opener so context lands faster.
- "Good vs. meh" replaces "Good vs. Blah".
- Tightens the closing on each section without going clipped — e.g. `If the answer to any of those is no, hold off until it is.`
- **Admin contact** collapsed from a four-line list into one sentence, with each admin linking to their `/community/#<id>` anchor.
- British spelling preserved (`organisations`, not `organizations`).

This is intended to supersede #41. Credit to @jensensics for the original direction — most of this PR carries his rewrite forward; the changes are mostly de-AI-ifying a few spots (`smells like noise`, `it'll fly`, flat `Cool.`), bringing back the metaphor, and tightening the moderation paragraph.

## Test plan
- [x] `pnpm check` passes (0 errors)
- [ ] Eyeball /guidelines/ in browser
- [ ] Confirm the four admin name links jump to the right anchors on /community/

🤖 Generated with [Claude Code](https://claude.com/claude-code)