### PR TITLE
feat: add partners page

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -54,6 +54,17 @@ const organisers = defineCollection({
   }),
 });
 
+const partners = defineCollection({
+  loader: file("src/content/partners/partners.yaml"),
+  schema: z.object({
+    id: kebabCaseId,
+    name: z.string(),
+    logo: z.string().optional().default(""),
+    url: z.string().optional().default(""),
+    description: z.string().optional().default(""),
+  }),
+});
+
 const sponsors = defineCollection({
   loader: file("src/content/sponsors/sponsors.yaml"),
   schema: z.object({
@@ -194,6 +205,7 @@ const faq = defineCollection({
 });
 
 export const collections = {
+  partners,
   members,
   organisers,
   sponsors,

--- a/src/content/partners/partners.yaml
+++ b/src/content/partners/partners.yaml
@@ -1,0 +1,29 @@
+- id: tinkercademy
+  name: Tinkercademy
+  logo: "/images/partners/tinkercademy.svg"
+  url: "https://tinkercademy.com"
+  description: "Coding and making education for kids and adults"
+
+- id: sg-code-campus
+  name: SG Code Campus
+  logo: "/images/partners/sg-code-campus.svg"
+  url: "https://sgcodecampus.com"
+  description: "Singapore's leading coding school for kids and teens"
+
+- id: success-it
+  name: Success IT
+  logo: "/images/partners/success-it.svg"
+  url: "https://successit.net"
+  description: "IT solutions and digital transformation"
+
+- id: lorong-ai
+  name: Lorong AI
+  logo: "/images/partners/lorong-ai.svg"
+  url: "https://lorong.ai"
+  description: "AI community and co-working space"
+
+- id: amcham
+  name: AmCham Singapore
+  logo: "/images/partners/amcham.svg"
+  url: "https://www.amcham.com.sg"
+  description: "American Chamber of Commerce in Singapore"

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -4,5 +4,6 @@ export const navLinks = [
   { href: "/showcase/", label: "showcase" },
   { href: "/jobs/", label: "jobs" },
   { href: "/events/", label: "events" },
+  { href: "/partners/", label: "partners" },
   { href: "/guidelines/", label: "guidelines" }
 ] as const;

--- a/src/pages/partners/index.astro
+++ b/src/pages/partners/index.astro
@@ -1,0 +1,136 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
+
+const partners = await getCollection("partners");
+---
+
+<BaseLayout
+  title="partners"
+  description="Partners and collaborators of the Agentic Builders Collective — organisations we work with regularly."
+>
+  <h1 class="page-title">Partners</h1>
+
+  <p class="page-intro">
+    Organisations we collaborate with regularly for meetups, workshops, and community building.
+  </p>
+
+  <div class="partners-grid">
+    {partners.map((partner) => (
+      <a
+        href={partner.data.url || undefined}
+        target={partner.data.url ? "_blank" : undefined}
+        rel={partner.data.url ? "noopener noreferrer" : undefined}
+        class="partner-card"
+      >
+        <div class="partner-logo">
+          {partner.data.logo ? (
+            <img src={partner.data.logo} alt={`${partner.data.name} logo`} loading="lazy" />
+          ) : (
+            <div class="partner-logo-placeholder">{partner.data.name.charAt(0)}</div>
+          )}
+        </div>
+        <h3 class="partner-name">{partner.data.name}</h3>
+        {partner.data.description && (
+          <p class="partner-description">{partner.data.description}</p>
+        )}
+      </a>
+    ))}
+  </div>
+
+  <section class="partner-cta">
+    <h2 class="section-label">Become a Partner</h2>
+    <p>
+      Want to collaborate with the Agentic Builders Collective? Reach out to us at{" "}
+      <a href="mailto:hello@agenticbuilders.sg">hello@agenticbuilders.sg</a>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .page-intro {
+    color: var(--muted);
+    margin-bottom: 32px;
+    max-width: 640px;
+  }
+
+  .partners-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 20px;
+    margin-bottom: 48px;
+  }
+
+  .partner-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 24px;
+    background: var(--panel);
+    text-decoration: none;
+    transition: background 0.15s ease;
+    border: 1px solid var(--line);
+  }
+
+  .partner-card:hover {
+    background: var(--panel-strong);
+  }
+
+  .partner-logo {
+    width: 80px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 16px;
+  }
+
+  .partner-logo img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+
+  .partner-logo-placeholder {
+    width: 64px;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--box-bg);
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--accent);
+  }
+
+  .partner-name {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+  }
+
+  .partner-description {
+    font-size: 13px;
+    color: var(--muted);
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  .partner-cta {
+    border-top: 1px solid var(--line);
+    padding-top: 32px;
+    margin-top: 16px;
+  }
+
+  .partner-cta p {
+    color: var(--muted);
+    max-width: 640px;
+  }
+
+  @media (max-width: 480px) {
+    .partners-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>


### PR DESCRIPTION
Adds a new /partners/ page showcasing organisations that collaborate regularly with the Agentic Builders Collective. Features a responsive grid layout, logo placeholders, and a CTA section for new partnerships.