### PR TITLE
feat: add calendar partners nomination and IA polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Then point your agent at the matching guide:
 | Request | Public page | Agent guide |
 |---------|-------------|-------------|
 | Add a person | `/community` | [`docs/add-person.md`](./docs/add-person.md) |
-| Add slides / a presentation | `/showcase` | [`docs/add-presentation.md`](./docs/add-presentation.md) |
 | Add an event | `/events` | [`docs/add-event.md`](./docs/add-event.md) |
 | Add a project | `/showcase` | [`docs/add-project.md`](./docs/add-project.md) |
 | Add an article | `/showcase/#articles` | [`docs/add-article.md`](./docs/add-article.md) |

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -5,6 +5,7 @@ The site uses Astro content collections defined in `src/content.config.ts`.
 For task-specific contribution instructions, start with:
 
 - `docs/id-guidelines.md`
+- `docs/information-architecture.md`
 - `docs/add-person.md`
 - `docs/add-presentation.md`
 - `docs/add-event.md`

--- a/docs/information-architecture.md
+++ b/docs/information-architecture.md
@@ -1,0 +1,65 @@
+# Information Architecture
+
+This site is for the Agentic Builders Collective, so its IA should preserve the community's actual operating model rather than forcing a generic marketing-site shape.
+
+## Accepted Principles
+
+- Keep the primary nav compact, but do not over-abstract it away from the real community surfaces.
+- `community` is the right public label for the member and organiser surface. Do not rename it to `people` unless the community direction changes.
+- `events` can be a broad hub. It is acceptable for Events to carry meetups, calendar access, external events, speaker nomination, recaps, and related participation actions.
+- `showcase` is not perfect, but `library` is not an accepted replacement. Do not rename Showcase to Library without a better naming decision.
+- `about` can absorb institutional context, especially partners and guidelines.
+- The footer should carry secondary navigation, contribution actions, and governance/contact links so the top nav does not grow every time a new page appears.
+
+## Current Primary Nav
+
+- about
+- community
+- showcase
+- events
+- jobs
+
+The WhatsApp CTA stays separate from the nav list.
+
+## Footer Grouping
+
+### explore
+
+- about
+- community
+- showcase
+- events
+- jobs
+
+### contribute
+
+- nominate speaker
+- github
+- add member
+- add project
+- add event
+- add article
+
+Keep `nominate speaker` and `github` before the pull-request contribution links.
+
+### collective
+
+- partners
+- guidelines
+- email
+- logo generator
+
+## Route Ownership
+
+- `/events/` owns the event experience. `/calendar/` may remain a direct view, but it should feel subordinate to Events rather than becoming a primary nav item.
+- `/nominate/` is an event participation action, not a primary nav item.
+- `/partners/` and `/guidelines/` are institutional pages. Keep them discoverable through About and the footer.
+- `/articles/` duplicates the article section inside Showcase. Prefer linking users to the Showcase article section unless a standalone articles experience gets a clearer purpose.
+- `/newsletters/...` is archival/community context. It should be surfaced through Events or Showcase only when it supports a specific story or recap.
+
+## Rejected Directions
+
+- Do not rename `community` to `people`.
+- Do not rename `showcase` to `library` as a default cleanup.
+- Do not treat Events as too broad merely because it includes calendar and participation actions.
+- Do not make every collection or contribution type a top-level nav item.

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,0 +1,77 @@
+---
+import { contributionLinks } from "../lib/contribution-links";
+
+const repoUrl = "https://github.com/agentic-builders-collective/agentic-builders-collective.github.io";
+
+type FooterLink = {
+  href: string;
+  label: string;
+  external?: boolean;
+  prefixArrow?: boolean;
+};
+
+const footerGroups: { title: string; links: FooterLink[] }[] = [
+  {
+    title: "explore",
+    links: [
+      { href: "/about/", label: "about" },
+      { href: "/community/", label: "community" },
+      { href: "/showcase/", label: "showcase" },
+      { href: "/events/", label: "events" },
+      { href: "/jobs/", label: "jobs" },
+    ],
+  },
+  {
+    title: "contribute",
+    links: [
+      { href: "/nominate/", label: "nominate speaker" },
+      { href: repoUrl, label: "github", external: true },
+      { href: contributionLinks.person, label: "add member", external: true, prefixArrow: true },
+      { href: contributionLinks.project, label: "add project", external: true, prefixArrow: true },
+      { href: contributionLinks.event, label: "add event", external: true, prefixArrow: true },
+      { href: contributionLinks.article, label: "add article", external: true, prefixArrow: true },
+    ],
+  },
+  {
+    title: "collective",
+    links: [
+      { href: "/partners/", label: "partners" },
+      { href: "/guidelines/", label: "guidelines" },
+      { href: "mailto:hello@agenticbuilders.sg", label: "email" },
+      { href: "/logo-generator", label: "logo generator" },
+    ],
+  },
+];
+---
+
+<footer class="site-footer">
+  <div class="site-footer-groups">
+    {
+      footerGroups.map((group) => (
+        <section class="site-footer-group" aria-labelledby={`footer-${group.title.replace(/\s+/g, "-")}`}>
+          <h2 id={`footer-${group.title.replace(/\s+/g, "-")}`}>{group.title}</h2>
+          <ul>
+            {group.links.map((link) => (
+              <li>
+                <a
+                  href={link.href}
+                  target={link.external ? "_blank" : undefined}
+                  rel={link.external ? "noopener noreferrer" : undefined}
+                >
+                  {link.prefixArrow && <span class="inline-arrow" aria-hidden="true">▶ </span>}
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))
+    }
+  </div>
+
+  <p class="site-footer-contact">
+    <a class="site-email" href="mailto:hello@agenticbuilders.sg">
+      <span class="footer-email-user">hello</span><span class="footer-email-at">@</span><span class="footer-email-host">agenticbuilders.sg</span>
+    </a>
+  </p>
+</footer>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -141,6 +141,7 @@ const events = defineCollection({
     sharedBy: legacyPersonRefs,
     tags: z.array(z.string()).default([]),
     status: z.enum(["upcoming", "past"]).default("past"),
+    tentative: z.boolean().optional().default(false),
     preEventSurvey: z.object({
       url: z.string().optional().default(""),
       closesAt: z.coerce.date().optional(),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -54,6 +54,17 @@ const organisers = defineCollection({
   }),
 });
 
+const partners = defineCollection({
+  loader: file("src/content/partners/partners.yaml"),
+  schema: z.object({
+    id: kebabCaseId,
+    name: z.string(),
+    logo: z.string().optional().default(""),
+    url: z.string().optional().default(""),
+    description: z.string().optional().default(""),
+  }),
+});
+
 const sponsors = defineCollection({
   loader: file("src/content/sponsors/sponsors.yaml"),
   schema: z.object({
@@ -195,6 +206,7 @@ const faq = defineCollection({
 });
 
 export const collections = {
+  partners,
   members,
   organisers,
   sponsors,

--- a/src/content/events/2026-07-24-abc-monthly-meetup.md
+++ b/src/content/events/2026-07-24-abc-monthly-meetup.md
@@ -1,0 +1,18 @@
+---
+title: "#8 - ABC Monthly Meetup"
+date: 2026-07-24
+kind: "meetup"
+time: "6:00 PM – 9:00 PM SGT"
+venue: "TBD"
+venueUrl: ""
+sponsorName: ""
+sponsorUrl: ""
+registrationUrl: ""
+attendance: 0
+speakers: []
+hosts: []
+tags: ["meetup"]
+status: "upcoming"
+tentative: true
+---
+Monthly meetup for the Agentic Builders Collective. Details to be confirmed.

--- a/src/content/events/2026-08-28-abc-monthly-meetup.md
+++ b/src/content/events/2026-08-28-abc-monthly-meetup.md
@@ -1,0 +1,18 @@
+---
+title: "#9 - ABC Monthly Meetup"
+date: 2026-08-28
+kind: "meetup"
+time: "6:00 PM – 9:00 PM SGT"
+venue: "TBD"
+venueUrl: ""
+sponsorName: ""
+sponsorUrl: ""
+registrationUrl: ""
+attendance: 0
+speakers: []
+hosts: []
+tags: ["meetup"]
+status: "upcoming"
+tentative: true
+---
+Monthly meetup for the Agentic Builders Collective. Details to be confirmed.

--- a/src/content/partners/partners.yaml
+++ b/src/content/partners/partners.yaml
@@ -1,0 +1,29 @@
+- id: tinkercademy
+  name: Tinkercademy
+  logo: "/images/partners/tinkercademy.svg"
+  url: "https://tinkercademy.com"
+  description: "Coding and making education for kids and adults"
+
+- id: sg-code-campus
+  name: SG Code Campus
+  logo: "/images/partners/sg-code-campus.svg"
+  url: "https://sgcodecampus.com"
+  description: "Singapore's leading coding school for kids and teens"
+
+- id: success-it
+  name: Success IT
+  logo: "/images/partners/success-it.svg"
+  url: "https://successit.net"
+  description: "IT solutions and digital transformation"
+
+- id: lorong-ai
+  name: Lorong AI
+  logo: "/images/partners/lorong-ai.svg"
+  url: "https://lorong.ai"
+  description: "AI community and co-working space"
+
+- id: amcham
+  name: AmCham Singapore
+  logo: "/images/partners/amcham.svg"
+  url: "https://www.amcham.com.sg"
+  description: "American Chamber of Commerce in Singapore"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import SiteHead from "../components/SiteHead.astro";
+import SiteFooter from "../components/SiteFooter.astro";
 import { navLinks } from "../lib/navigation";
 
 interface Props {
@@ -82,22 +83,7 @@ const isCurrent = (href: string) => {
         <slot />
       </main>
 
-      <p class="site-footer-contact">
-        <a class="site-email" href="mailto:hello@agenticbuilders.sg">
-          <span class="footer-email-user">hello</span><span class="footer-email-at">@</span><span class="footer-email-host">agenticbuilders.sg</span>
-        </a>
-        <span class="footer-contact-separator" aria-hidden="true"> • </span>
-        <a
-          class="footer-github-link"
-          href="https://github.com/agentic-builders-collective/agentic-builders-collective.github.io"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          github
-        </a>
-        <span class="footer-contact-separator" aria-hidden="true"> • </span>
-        <a class="footer-github-link" href="/logo-generator">logo generator</a>
-      </p>
+      <SiteFooter />
     </div>
 
     <script>

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -2,10 +2,6 @@ export const navLinks = [
   { href: "/about/", label: "about" },
   { href: "/community/", label: "community" },
   { href: "/showcase/", label: "showcase" },
-  { href: "/jobs/", label: "jobs" },
   { href: "/events/", label: "events" },
-  { href: "/calendar/", label: "calendar" },
-  { href: "/partners/", label: "partners" },
-  { href: "/nominate/", label: "nominate" },
-  { href: "/guidelines/", label: "guidelines" }
+  { href: "/jobs/", label: "jobs" }
 ] as const;

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -6,5 +6,6 @@ export const navLinks = [
   { href: "/events/", label: "events" },
   { href: "/calendar/", label: "calendar" },
   { href: "/partners/", label: "partners" },
+  { href: "/nominate/", label: "nominate" },
   { href: "/guidelines/", label: "guidelines" }
 ] as const;

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -5,5 +5,6 @@ export const navLinks = [
   { href: "/jobs/", label: "jobs" },
   { href: "/events/", label: "events" },
   { href: "/calendar/", label: "calendar" },
+  { href: "/partners/", label: "partners" },
   { href: "/guidelines/", label: "guidelines" }
 ] as const;

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -4,5 +4,6 @@ export const navLinks = [
   { href: "/showcase/", label: "showcase" },
   { href: "/jobs/", label: "jobs" },
   { href: "/events/", label: "events" },
+  { href: "/calendar/", label: "calendar" },
   { href: "/guidelines/", label: "guidelines" }
 ] as const;

--- a/src/pages/calendar/index.astro
+++ b/src/pages/calendar/index.astro
@@ -5,14 +5,19 @@ import { getCollection } from "astro:content";
 const allEvents = await getCollection("events");
 
 const now = new Date();
-const today = new Date(now.setHours(0,0,0,0));
+const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+
+const toUtcDate = (value: Date | string) => {
+  const date = value instanceof Date ? value : new Date(value);
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+};
 
 // Group events by year-month
 const eventsByMonth = new Map<string, typeof allEvents>();
 
 for (const event of allEvents) {
-  const date = new Date(event.data.date);
-  const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+  const date = toUtcDate(event.data.date);
+  const key = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
   if (!eventsByMonth.has(key)) {
     eventsByMonth.set(key, []);
   }
@@ -33,13 +38,13 @@ const formatMonth = (key: string) => {
 };
 
 const formatDay = (date: Date | string) => {
-  const d = date instanceof Date ? date : new Date(date);
-  return d.getDate();
+  const d = toUtcDate(date);
+  return d.getUTCDate();
 };
 
 const formatWeekday = (date: Date | string) => {
-  const d = date instanceof Date ? date : new Date(date);
-  return d.toLocaleDateString("en-SG", { weekday: "short" });
+  const d = toUtcDate(date);
+  return d.toLocaleDateString("en-SG", { weekday: "short", timeZone: "UTC" });
 };
 ---
 
@@ -68,7 +73,7 @@ const formatWeekday = (date: Date | string) => {
           <div class="month-events">
             {events.map((event) => {
               const isTentative = event.data.tentative ?? false;
-              const eventDate = new Date(event.data.date);
+              const eventDate = toUtcDate(event.data.date);
               const isPast = eventDate < today;
               return (
                 <a

--- a/src/pages/calendar/index.astro
+++ b/src/pages/calendar/index.astro
@@ -1,0 +1,294 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
+
+const allEvents = await getCollection("events");
+
+const now = new Date();
+const today = new Date(now.setHours(0,0,0,0));
+
+// Group events by year-month
+const eventsByMonth = new Map<string, typeof allEvents>();
+
+for (const event of allEvents) {
+  const date = new Date(event.data.date);
+  const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+  if (!eventsByMonth.has(key)) {
+    eventsByMonth.set(key, []);
+  }
+  eventsByMonth.get(key)!.push(event);
+}
+
+// Sort months
+const sortedMonths = Array.from(eventsByMonth.keys()).sort();
+
+const monthNames = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"
+];
+
+const formatMonth = (key: string) => {
+  const [year, month] = key.split("-");
+  return `${monthNames[parseInt(month) - 1]} ${year}`;
+};
+
+const formatDay = (date: Date | string) => {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.getDate();
+};
+
+const formatWeekday = (date: Date | string) => {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleDateString("en-SG", { weekday: "short" });
+};
+---
+
+<BaseLayout
+  title="calendar"
+  description="Monthly meetup calendar for the Agentic Builders Collective — tentative and confirmed dates for our Singapore meetups."
+>
+  <h1 class="page-title">Calendar</h1>
+
+  <p class="page-intro">
+    Monthly meetup dates for the Agentic Builders Collective.
+    <span class="calendar-legend">
+      <span class="legend-item confirmed">Confirmed</span>
+      <span class="legend-item tentative">Tentative</span>
+    </span>
+  </p>
+
+  <div class="calendar-container">
+    {sortedMonths.map((monthKey) => {
+      const events = eventsByMonth.get(monthKey)!.sort(
+        (a, b) => new Date(a.data.date).getTime() - new Date(b.data.date).getTime()
+      );
+      return (
+        <section class="calendar-month">
+          <h2 class="month-heading">{formatMonth(monthKey)}</h2>
+          <div class="month-events">
+            {events.map((event) => {
+              const isTentative = event.data.tentative ?? false;
+              const eventDate = new Date(event.data.date);
+              const isPast = eventDate < today;
+              return (
+                <a
+                  href={`/events/#${event.id}`}
+                  class={`event-card ${isTentative ? "tentative" : "confirmed"} ${isPast ? "past" : ""}`}
+                >
+                  <div class="event-date">
+                    <span class="event-day">{formatDay(event.data.date)}</span>
+                    <span class="event-weekday">{formatWeekday(event.data.date)}</span>
+                  </div>
+                  <div class="event-info">
+                    <h3 class="event-title">{event.data.title}</h3>
+                    <div class="event-meta">
+                      {event.data.time && <span class="event-time">{event.data.time}</span>}
+                      {event.data.venue && <span class="event-venue">{event.data.venue}</span>}
+                    </div>
+                    <div class="event-tags">
+                      {isTentative && <span class="tag tentative">tentative</span>}
+                      {!isTentative && !isPast && <span class="tag confirmed">confirmed</span>}
+                      {isPast && <span class="tag past">past</span>}
+                    </div>
+                  </div>
+                </a>
+              );
+            })}
+          </div>
+        </section>
+      );
+    })}
+  </div>
+</BaseLayout>
+
+<style>
+  .page-intro {
+    color: var(--muted);
+    margin-bottom: 32px;
+    max-width: 640px;
+  }
+
+  .calendar-legend {
+    display: inline-flex;
+    gap: 16px;
+    margin-left: 16px;
+  }
+
+  .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+  }
+
+  .legend-item::before {
+    content: "";
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+  }
+
+  .legend-item.confirmed::before {
+    background: #4ade80;
+  }
+
+  .legend-item.tentative::before {
+    background: #fbbf24;
+  }
+
+  .calendar-container {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+  }
+
+  .calendar-month {
+    border-top: 1px solid var(--line);
+    padding-top: 24px;
+  }
+
+  .month-heading {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+    color: var(--accent);
+  }
+
+  .month-events {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .event-card {
+    display: flex;
+    gap: 16px;
+    padding: 16px;
+    background: var(--panel);
+    border-left: 3px solid var(--line);
+    text-decoration: none;
+    transition: background 0.15s ease;
+  }
+
+  .event-card:hover {
+    background: var(--panel-strong);
+  }
+
+  .event-card.confirmed {
+    border-left-color: #4ade80;
+  }
+
+  .event-card.tentative {
+    border-left-color: #fbbf24;
+  }
+
+  .event-card.past {
+    opacity: 0.6;
+  }
+
+  .event-date {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: 48px;
+    padding: 4px 8px;
+    background: var(--box-bg);
+    border-radius: var(--radius-sm);
+  }
+
+  .event-day {
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .event-weekday {
+    font-size: 11px;
+    color: var(--muted);
+    margin-top: 2px;
+  }
+
+  .event-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .event-title {
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0 0 6px 0;
+    line-height: 1.3;
+  }
+
+  .event-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    font-size: 13px;
+    color: var(--muted);
+    margin-bottom: 8px;
+  }
+
+  .event-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .event-tags {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+  .tag {
+    display: inline-block;
+    padding: 2px 8px;
+    font-size: 11px;
+    font-weight: 500;
+    border-radius: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+  }
+
+  .tag.confirmed {
+    background: rgba(74, 222, 128, 0.15);
+    color: #4ade80;
+  }
+
+  .tag.tentative {
+    background: rgba(251, 191, 36, 0.15);
+    color: #fbbf24;
+  }
+
+  .tag.past {
+    background: rgba(166, 184, 217, 0.15);
+    color: var(--muted);
+  }
+
+  @media (max-width: 480px) {
+    .event-card {
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .event-date {
+      flex-direction: row;
+      gap: 6px;
+      min-width: unset;
+      align-self: flex-start;
+    }
+
+    .event-day {
+      font-size: 16px;
+    }
+
+    .calendar-legend {
+      display: flex;
+      margin-left: 0;
+      margin-top: 8px;
+    }
+  }
+</style>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -115,6 +115,29 @@ const chatDigests = [
       justify-self: start;
     }
 
+    .events-page-actions {
+      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin: 0 0 24px;
+    }
+
+    .events-page-actions a {
+      border: 1px solid rgba(215, 228, 248, 0.2);
+      color: var(--accent);
+      font-size: 1rem;
+      letter-spacing: 0.08em;
+      padding: 8px 12px;
+      text-decoration: none;
+    }
+
+    .events-page-actions a:hover,
+    .events-page-actions a:focus-visible {
+      background: rgba(215, 228, 248, 0.08);
+      color: var(--text);
+    }
+
     .list-item {
       scroll-margin-top: 96px;
     }
@@ -354,6 +377,11 @@ const chatDigests = [
   </style>
 
   <h1 class="page-title">Events</h1>
+
+  <div class="events-page-actions" aria-label="Event actions">
+    <a href="/calendar/">Calendar view <span class="inline-arrow" aria-hidden="true">▶</span></a>
+    <a href="/nominate/">Nominate a speaker <span class="inline-arrow" aria-hidden="true">▶</span></a>
+  </div>
 
   <section>
     <h3 class="section-label">Upcoming</h3>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -378,10 +378,10 @@ const chatDigests = [
 
   <h1 class="page-title">Events</h1>
 
-  <div class="events-page-actions" aria-label="Event actions">
+  <nav class="events-page-actions" aria-label="Event actions">
     <a href="/calendar/">Calendar view <span class="inline-arrow" aria-hidden="true">▶</span></a>
     <a href="/nominate/">Nominate a speaker <span class="inline-arrow" aria-hidden="true">▶</span></a>
-  </div>
+  </nav>
 
   <section>
     <h3 class="section-label">Upcoming</h3>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import SiteHead from "../components/SiteHead.astro";
+import SiteFooter from "../components/SiteFooter.astro";
 import { getCollection } from "astro:content";
 import { contributionLinks } from "../lib/contribution-links";
 import { navLinks } from "../lib/navigation";
@@ -185,7 +186,7 @@ const isCurrent = (href: string) => {
         margin: 0 auto;
         max-width: 800px;
         min-height: 100vh;
-        padding: 64px 20px 24px;
+        padding: 24px 20px;
         width: 100%;
       }
 
@@ -573,22 +574,7 @@ const isCurrent = (href: string) => {
         </section>
       )}
 
-      <p class="site-footer-contact">
-        <a class="site-email" href="mailto:hello@agenticbuilders.sg">
-          <span class="footer-email-user">hello</span><span class="footer-email-at">@</span><span class="footer-email-host">agenticbuilders.sg</span>
-        </a>
-        <span class="footer-contact-separator" aria-hidden="true"> • </span>
-        <a
-          class="footer-github-link"
-          href="https://github.com/agentic-builders-collective/agentic-builders-collective.github.io"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          github
-        </a>
-        <span class="footer-contact-separator" aria-hidden="true"> • </span>
-        <a class="footer-github-link" href="/logo-generator">logo generator</a>
-      </p>
+      <SiteFooter />
     </div>
 
     <script>

--- a/src/pages/nominate/index.astro
+++ b/src/pages/nominate/index.astro
@@ -1,0 +1,253 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+---
+
+<BaseLayout
+  title="nominate a speaker"
+  description="Nominate a speaker for an upcoming Agentic Builders Collective meetup. Submit yourself or someone else."
+>
+  <h1 class="page-title">Nominate a Speaker</h1>
+
+  <p class="page-intro">
+    Have someone in mind who would be great for one of our meetups? Or want to nominate yourself?
+    Fill out the form below and we will be in touch.
+  </p>
+
+  <form
+    id="nomination-form"
+    class="nomination-form"
+    onsubmit="(function(e){e.preventDefault(); handleSubmit();})(event)"
+  >
+    <div class="form-group">
+      <label for="nominator-name">Your Name</label>
+      <input type="text" id="nominator-name" name="nominatorName" required placeholder="Your full name" />
+    </div>
+
+    <div class="form-group">
+      <label for="nominator-email">Your Email</label>
+      <input type="email" id="nominator-email" name="nominatorEmail" required placeholder="you@example.com" />
+    </div>
+
+    <div class="form-group">
+      <label for="speaker-name">Speaker Name</label>
+      <input type="text" id="speaker-name" name="speakerName" required placeholder="Who do you want to nominate?" />
+    </div>
+
+    <div class="form-group">
+      <label for="speaker-email">Speaker Email (optional)</label>
+      <input type="email" id="speaker-email" name="speakerEmail" placeholder="speaker@example.com" />
+    </div>
+
+    <div class="form-group">
+      <label for="topic">Proposed Topic or Title</label>
+      <input type="text" id="topic" name="topic" required placeholder="What would they talk about?" />
+    </div>
+
+    <div class="form-group">
+      <label for="description">Brief Description</label>
+      <textarea id="description" name="description" rows="4" placeholder="A few sentences about the topic, why it is relevant, and what the audience would learn."></textarea>
+    </div>
+
+    <div class="form-group">
+      <label for="event-preference">Preferred Event (optional)</label>
+      <select id="event-preference" name="eventPreference">
+        <option value="">Any upcoming meetup</option>
+        <option value="2026-07">July 2026</option>
+        <option value="2026-08">August 2026</option>
+        <option value="2026-09">September 2026</option>
+        <option value="2026-10">October 2026</option>
+      </select>
+    </div>
+
+    <div class="form-group">
+      <label for="speaker-background">Speaker Background (optional)</label>
+      <textarea id="speaker-background" name="speakerBackground" rows="3" placeholder="Links to previous talks, LinkedIn, GitHub, or any relevant background."></textarea>
+    </div>
+
+    <div class="form-group">
+      <label class="checkbox-label">
+        <input type="checkbox" id="self-nomination" name="selfNomination" />
+        <span>I am nominating myself</span>
+      </label>
+    </div>
+
+    <button type="submit" class="submit-btn">Submit Nomination</button>
+  </form>
+
+  <div id="form-result" class="form-result hidden">
+    <h3>Thank you!</h3>
+    <p>Your nomination has been prepared. An email will open in your default email client to send it to us.</p>
+    <p>If no email client opens, you can manually email <a href="mailto:hello@agenticbuilders.sg">hello@agenticbuilders.sg</a></p>
+  </div>
+</BaseLayout>
+
+<script is:inline>
+  function handleSubmit() {
+    const form = document.getElementById('nomination-form');
+    const formData = new FormData(form);
+    
+    const nominatorName = formData.get('nominatorName');
+    const nominatorEmail = formData.get('nominatorEmail');
+    const speakerName = formData.get('speakerName');
+    const speakerEmail = formData.get('speakerEmail') || 'Not provided';
+    const topic = formData.get('topic');
+    const description = formData.get('description') || 'Not provided';
+    const eventPreference = formData.get('eventPreference') || 'Any upcoming meetup';
+    const speakerBackground = formData.get('speakerBackground') || 'Not provided';
+    const selfNomination = formData.get('selfNomination') ? 'Yes' : 'No';
+
+    const subject = `Speaker Nomination: ${speakerName} - ${topic}`;
+    const body = `Speaker Nomination for Agentic Builders Collective
+
+NOMINATOR
+Name: ${nominatorName}
+Email: ${nominatorEmail}
+
+SPEAKER
+Name: ${speakerName}
+Email: ${speakerEmail}
+Topic: ${topic}
+
+DESCRIPTION
+${description}
+
+PREFERRED EVENT
+${eventPreference}
+
+SPEAKER BACKGROUND
+${speakerBackground}
+
+SELF NOMINATION
+${selfNomination}
+
+---
+Submitted via agenticbuilders.sg/nominate
+`;
+
+    const mailtoLink = `mailto:hello@agenticbuilders.sg?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+    
+    window.location.href = mailtoLink;
+    
+    document.getElementById('form-result').classList.remove('hidden');
+    form.style.opacity = '0.5';
+    form.style.pointerEvents = 'none';
+  }
+</script>
+
+<style>
+  .page-intro {
+    color: var(--muted);
+    margin-bottom: 32px;
+    max-width: 640px;
+  }
+
+  .nomination-form {
+    max-width: 560px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .form-group label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--accent);
+  }
+
+  .form-group input,
+  .form-group textarea,
+  .form-group select {
+    padding: 10px 12px;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 14px;
+    outline: none;
+  }
+
+  .form-group input:focus,
+  .form-group textarea:focus,
+  .form-group select:focus {
+    border-color: var(--accent);
+  }
+
+  .form-group textarea {
+    resize: vertical;
+    min-height: 80px;
+  }
+
+  .form-group select {
+    appearance: none;
+    cursor: pointer;
+  }
+
+  .form-group select option {
+    background: var(--bg);
+    color: var(--text);
+  }
+
+  .checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+  }
+
+  .checkbox-label input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--accent);
+  }
+
+  .submit-btn {
+    padding: 12px 24px;
+    background: var(--accent);
+    color: var(--bg);
+    border: none;
+    font-family: var(--font-sans);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s ease;
+    align-self: flex-start;
+  }
+
+  .submit-btn:hover {
+    opacity: 0.85;
+  }
+
+  .form-result {
+    margin-top: 24px;
+    padding: 20px;
+    background: var(--panel);
+    border: 1px solid var(--line);
+  }
+
+  .form-result.hidden {
+    display: none;
+  }
+
+  .form-result h3 {
+    margin: 0 0 8px 0;
+    font-size: 16px;
+  }
+
+  .form-result p {
+    margin: 0 0 6px 0;
+    color: var(--muted);
+    font-size: 13px;
+  }
+
+  @media (max-width: 480px) {
+    .nomination-form {
+      max-width: 100%;
+    }
+  }
+</style>

--- a/src/pages/partners/index.astro
+++ b/src/pages/partners/index.astro
@@ -1,0 +1,136 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
+
+const partners = await getCollection("partners");
+---
+
+<BaseLayout
+  title="partners"
+  description="Partners and collaborators of the Agentic Builders Collective — organisations we work with regularly."
+>
+  <h1 class="page-title">Partners</h1>
+
+  <p class="page-intro">
+    Organisations we collaborate with regularly for meetups, workshops, and community building.
+  </p>
+
+  <div class="partners-grid">
+    {partners.map((partner) => (
+      <a
+        href={partner.data.url || undefined}
+        target={partner.data.url ? "_blank" : undefined}
+        rel={partner.data.url ? "noopener noreferrer" : undefined}
+        class="partner-card"
+      >
+        <div class="partner-logo">
+          {partner.data.logo ? (
+            <img src={partner.data.logo} alt={`${partner.data.name} logo`} loading="lazy" />
+          ) : (
+            <div class="partner-logo-placeholder">{partner.data.name.charAt(0)}</div>
+          )}
+        </div>
+        <h3 class="partner-name">{partner.data.name}</h3>
+        {partner.data.description && (
+          <p class="partner-description">{partner.data.description}</p>
+        )}
+      </a>
+    ))}
+  </div>
+
+  <section class="partner-cta">
+    <h2 class="section-label">Become a Partner</h2>
+    <p>
+      Want to collaborate with the Agentic Builders Collective? Reach out to us at{" "}
+      <a href="mailto:hello@agenticbuilders.sg">hello@agenticbuilders.sg</a>
+    </p>
+  </section>
+</BaseLayout>
+
+<style>
+  .page-intro {
+    color: var(--muted);
+    margin-bottom: 32px;
+    max-width: 640px;
+  }
+
+  .partners-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 20px;
+    margin-bottom: 48px;
+  }
+
+  .partner-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 24px;
+    background: var(--panel);
+    text-decoration: none;
+    transition: background 0.15s ease;
+    border: 1px solid var(--line);
+  }
+
+  .partner-card:hover {
+    background: var(--panel-strong);
+  }
+
+  .partner-logo {
+    width: 80px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 16px;
+  }
+
+  .partner-logo img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+
+  .partner-logo-placeholder {
+    width: 64px;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--box-bg);
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--accent);
+  }
+
+  .partner-name {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+  }
+
+  .partner-description {
+    font-size: 13px;
+    color: var(--muted);
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  .partner-cta {
+    border-top: 1px solid var(--line);
+    padding-top: 32px;
+    margin-top: 16px;
+  }
+
+  .partner-cta p {
+    color: var(--muted);
+    max-width: 640px;
+  }
+
+  @media (max-width: 480px) {
+    .partners-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -80,11 +80,11 @@ a {
   margin: 0 auto;
   max-width: 800px;
   min-height: 100vh;
-  padding: 64px 20px 24px;
+  padding: 24px 20px;
   width: 100%;
 }
 
-/* ── Brand (pinned top-left) ── */
+/* ── Brand ── */
 
 .brand {
   align-items: center;
@@ -94,7 +94,7 @@ a {
   font-weight: 700;
   left: 20px;
   letter-spacing: 0.08em;
-  position: fixed;
+  position: absolute;
   text-decoration: none;
   top: 20px;
   z-index: 21;
@@ -128,22 +128,19 @@ a {
   50% { opacity: 0; }
 }
 
-/* ── Fixed top menu ── */
+/* ── Top menu ── */
 
 .site-top-menu,
 .home-top-menu {
   align-items: center;
-  background: rgba(2, 4, 12, 0.92);
-  backdrop-filter: blur(8px);
+  background: rgb(30, 30, 40);
+  border-bottom: 1px solid var(--line);
   display: flex;
   flex-direction: column;
   gap: 8px;
   justify-content: center;
-  left: 50%;
   padding: 20px 0 16px;
-  position: fixed;
-  top: 0;
-  transform: translateX(-50%);
+  position: relative;
   transition: background-color 200ms ease;
   width: 100%;
   z-index: 20;
@@ -307,12 +304,6 @@ a {
 }
 
 @media (max-width: 1100px) {
-  .brand,
-  .site-top-menu,
-  .home-top-menu {
-    position: absolute;
-  }
-
   .site-top-menu,
   .home-top-menu {
     display: flex !important;
@@ -353,7 +344,53 @@ a {
   }
 }
 
-/* ── Email (bottom when short, natural when long) ── */
+/* ── Footer ── */
+
+.site-footer {
+  align-self: center;
+  background: var(--box-bg);
+  border-top: 1px solid var(--line);
+  margin: 48px calc(50% - 50vw) 0;
+  padding: 32px max(20px, calc((100vw - 800px) / 2 + 20px)) 24px;
+  width: 100vw;
+}
+
+.site-footer-groups {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.site-footer-group h2 {
+  color: var(--accent);
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 12px;
+}
+
+.site-footer-group ul {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.site-footer-group a {
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+}
+
+.site-footer-group a:hover,
+.site-footer-group a:focus-visible {
+  color: var(--text);
+}
 
 .site-footer-contact {
   align-items: center;
@@ -363,9 +400,14 @@ a {
   gap: 0;
   justify-content: center;
   letter-spacing: 0.08em;
-  margin-top: auto;
-  padding: 48px 0 24px;
+  margin: 32px 0 0;
   text-align: center;
+}
+
+@media (max-width: 720px) {
+  .site-footer-groups {
+    grid-template-columns: 1fr;
+  }
 }
 
 .site-email {
@@ -806,7 +848,7 @@ p {
 
 @media (max-width: 640px) {
   .shell {
-    padding: 64px 14px 40px;
+    padding: 24px 14px 40px;
   }
 
   .list-item,


### PR DESCRIPTION
## Summary
- integrate the calendar, partners, and speaker nomination feature PRs into one reviewed branch
- keep the global nav compact and demote secondary pages/actions into a grouped full-width footer
- document the accepted information architecture decisions for future contributor work
- make the header a solid unpinned band and add Events page actions for calendar and speaker nomination

## Supersedes
- Closes #59
- Closes #60
- Closes #61

## Not included
- #62 is intentionally left separate because it removes project feature images and touches a different surface

## Validation
- pnpm check
- pnpm build
- rendered smoke check at http://127.0.0.1:4322/ and /events/ with no console errors
