### PR TITLE
Add Lennon Chia community profile

### DIFF
--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -264,3 +264,17 @@
   twitter: ""
   addedAt: "2026-05-28T10:50:45Z"
   featured: false
+
+- id: chia-min-jun-lennon
+  name: Chia Min Jun Lennon
+  aliases:
+    - Lennon Chia
+    - 13ernkastel
+    - Hinotoi-agent
+  tagline: AI agent security, retrieval, and backend hardening.
+  company: ""
+  website: https://github.com/13ernkastel
+  linkedin: https://www.linkedin.com/in/lennon-chia/
+  github: https://github.com/Hinotoi-agent
+  addedAt: "2026-06-03T02:55:39Z"
+  featured: false


### PR DESCRIPTION
## Summary
- add Lennon Chia as a community member
- include LinkedIn plus both GitHub profiles via the profile website and GitHub fields

## Validation
- pnpm check
- pnpm build