### PR TITLE
Add Lennon Chia community profile

### DIFF
--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -272,7 +272,7 @@
     - 13ernkastel
     - Hinotoi-agent
   tagline: AI agent security, retrieval, and backend hardening.
-  company: ""
+  company: EY
   website: https://github.com/13ernkastel
   linkedin: https://www.linkedin.com/in/lennon-chia/
   github: https://github.com/Hinotoi-agent

--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -264,3 +264,17 @@
   twitter: ""
   addedAt: "2026-05-28T10:50:45Z"
   featured: false
+
+- id: chia-min-jun-lennon
+  name: Chia Min Jun Lennon
+  aliases:
+    - Lennon Chia
+    - 13ernkastel
+    - Hinotoi-agent
+  tagline: AI agent security, retrieval, and backend hardening.
+  company: ""
+  website: https://github.com/13ernkastel
+  linkedin: https://www.linkedin.com/in/lennon-chia/
+  github: https://github.com/Hinotoi-agent
+  addedAt: "2026-06-03T02:55:39Z"
+  featured: false

--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -271,9 +271,9 @@
     - Lennon Chia
     - 13ernkastel
     - Hinotoi-agent
-  tagline: AI agent security, retrieval, and backend hardening.
+  tagline: AI agent security, retrieval, and backend hardening. Views are individual and do not represent the firm.
   company: EY
-  website: https://github.com/13ernkastel
+  website: https://www.ey.com/en_sg
   linkedin: https://www.linkedin.com/in/lennon-chia/
   github: https://github.com/Hinotoi-agent
   addedAt: "2026-06-03T02:55:39Z"


### PR DESCRIPTION
## Summary
- add Lennon Chia as a community member
- set organization/company to EY
- include LinkedIn plus both GitHub profiles via the profile website and GitHub fields

## Validation
- `git diff --check`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm check` (0 errors; existing hints only)
- `corepack pnpm build`

## Note
This replaces the previously closed PR #65. That PR cannot be reopened because GitHub reports that its original head repository was deleted.