### PR TITLE
feat: add Mythos & The Curated Frontier external event

### DIFF
--- a/src/content/events/2026-06-16-mythos-the-curated-frontier.md
+++ b/src/content/events/2026-06-16-mythos-the-curated-frontier.md
@@ -1,0 +1,16 @@
+---
+title: "Mythos & The Curated Frontier"
+date: 2026-06-16
+kind: external
+time: "5:00 PM – 6:00 PM SGT"
+venue: "AmChamSG Hub, 1 Scotts Road, #23-03, Shaw Centre, Singapore"
+venueUrl: ""
+registrationUrl: "https://amchamsg.glueup.com/event/free-mythos-the-curated-frontier-181865/"
+status: upcoming
+---
+
+In April 2026, Anthropic released its most powerful AI model to date. They also chose not to ship it. Mythos sits with around fifty named partners. The rest of the world is locked out. It is the first time a frontier lab has openly said: we built it, and we are not going to release it.
+
+That single decision is already reshaping cyber defence, capital markets, regulatory expectations, and the physical cost of compute. In the 1960s, mainframes created a world where only a few institutions could access frontier compute. Frontier AI may be taking us back there — only at far greater speed.
+
+Join the AmChamSG Technology, Media & Telecommunications Committee, Cybersecurity Committee, Legal & IPR Committee and Sustainability & Environment Committee for an important conversation on how curated frontier AI is reshaping capability, governance, cost, and the business models built on top of them.


### PR DESCRIPTION
Adds the AmChamSG **Mythos & The Curated Frontier** event (16 Jun 2026, external) to the events page.

Reworks the contribution from #64 to fit the repo and the updated events layout:
- Moves the file into `src/content/events/` (the original was added at the repo root, so the content collection never loaded it) and fixes the filename (`… (1).md` → kebab-case).
- Quotes the `venue` YAML — the unquoted ` #23-03` was being parsed as a comment and truncated the address.
- `kind: external` → renders in the **External Events** section, with its description now showing (external descriptions were recently fixed).

Closes #64

Co-authored-by: @hsienlei-collab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
