### PR TITLE
Add code riff hosts, an episode, and a project to Showcase

### DIFF
--- a/src/content/articles/articles.yaml
+++ b/src/content/articles/articles.yaml
@@ -24,3 +24,17 @@
     - workshops
     - agents
     - presentations
+- id: code-riff-gaurav-keerthi-cybersecurity
+  title: "Cybersecurity shouldn't be a luxury | Gaurav Keerthi (CEO of StrongKeep)"
+  authors:
+    - personId: eric-tan
+    - personId: yaohong-chng
+  url: https://www.youtube.com/watch?v=UNBkWOIw-IM
+  publication: code riff
+  date: 2026-06-16
+  summary: a code riff conversation with Gaurav Keerthi, former Deputy Chief Executive of Singapore's Cyber Security Agency and now CEO of StrongKeep, on using AI without leaking your data or API keys, building your own lightweight harnesses, and why good cybersecurity shouldn't be a luxury for small teams.
+  tags:
+    - security
+    - cybersecurity
+    - ai
+    - podcast

--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -289,3 +289,30 @@
   github: https://github.com/Guaaaaaaaan
   addedAt: "2026-06-14T12:39:00Z"
   featured: false
+
+- id: eric-tan
+  name: Eric Tan
+  aliases:
+    - erictisme
+  tagline: co-host of code riff pod for people to use ai for flourishing and fun, about to join an sme to transform it with ai and consulting expertise
+  company: code riff
+  website: https://www.linkedin.com/company/code-riff/
+  linkedin: https://www.linkedin.com/in/erictisme/
+  github: https://github.com/erictisme
+  youtube: https://www.youtube.com/@CodeRiffAI
+  addedAt: "2026-06-18T10:35:25Z"
+  featured: false
+
+- id: yaohong-chng
+  name: Yaohong Chng
+  aliases:
+    - mrkre
+    - Yaohong C
+  tagline: AI consulting with Superuser HQ, and co-host of code riff.
+  company: Superuser HQ
+  website: https://superuserhq.com/
+  linkedin: https://www.linkedin.com/in/yaohongchng/
+  github: https://github.com/mrkre
+  youtube: https://www.youtube.com/@CodeRiffAI
+  addedAt: "2026-06-18T10:35:30Z"
+  featured: false

--- a/src/content/projects/lennys-greatest-hits.md
+++ b/src/content/projects/lennys-greatest-hits.md
@@ -1,0 +1,14 @@
+---
+title: Lenny's Greatest Hits
+makers:
+  - personId: eric-tan
+url: https://lennys-greatest-hits.vercel.app/
+builtWith:
+  - Next.js
+  - Vercel
+featured: false
+summary: 102 original songs across 11 albums, generated from Lenny Rachitsky's 349 newsletters and 289 podcast episodes. it turns his product wisdom into 2-3 minute tracks you can stream and shuffle. made in singapore.
+date: 2026-06-18
+---
+
+102 ai-generated songs that turn Lenny Rachitsky's product writing and podcast archive into music. eleven themed albums, each track 2-3 minutes, built on code riff ai. hit play or shuffle.


### PR DESCRIPTION
Adds the two code riff hosts as community members, plus a Showcase article and a project.

**Members** (`src/content/members/members.yaml`)
- Eric Tan (`erictisme`)
- Yaohong Ch'ng (`mrkre`)

**Article** (`src/content/articles/articles.yaml`)
- "Cybersecurity shouldn't be a luxury | Gaurav Keerthi (CEO of StrongKeep)" — a code riff conversation, authored by the two members above (linked via `personId`).

**Project** (`src/content/projects/lennys-greatest-hits.md`)
- Lenny's Greatest Hits — 102 AI-generated songs distilled from Lenny Rachitsky's newsletters and podcast archive, built by Eric Tan (`eric-tan`).

Notes:
- Followed `docs/add-person.md`, `docs/add-article.md`, and `docs/add-project.md`. Changes are additive and don't reformat existing entries.
- Gaurav Keerthi is already a member; the episode references the ABC community (credited in the YouTube description as how we met).
