### PR TITLE
[codex] add Data Scorecard research roles

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,6 +23,6 @@ export default defineConfig({
   site: "https://www.agenticbuilders.sg",
   server: {
     host: true,
-    allowedHosts: ["yjmbpro.local"],
+    allowedHosts: ["yjmbpro", "yjmbpro.local"],
   },
 });

--- a/docs/add-job.md
+++ b/docs/add-job.md
@@ -24,6 +24,7 @@ Job:
 - Location:
 - Work mode: onsite | hybrid | remote
 - Employment type: full-time | part-time | contract | internship | fractional
+- Employment types, for a combined post:
 - Apply URL:
 - Contact email:
 - Posted at:
@@ -79,6 +80,7 @@ Short role description here.
 - `location`: role location, for example `Singapore`, `Remote`, or `APAC`.
 - `workMode`: one of `onsite`, `hybrid`, or `remote`.
 - `employmentType`: one of `full-time`, `part-time`, `contract`, `internship`, or `fractional`.
+- `employmentTypes`: optional array of the same values for a combined post covering multiple roles.
 - `applyUrl`: application link. Required unless `contactEmail` is present.
 - `contactEmail`: fallback contact email. Required unless `applyUrl` is present.
 - `postedAt`: date the post should appear as published.

--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -291,7 +291,7 @@ status: open
 Short role description here.
 ```
 
-`workMode` must be `onsite`, `hybrid`, or `remote`. `employmentType` must be `full-time`, `part-time`, `contract`, `internship`, or `fractional`. Use `status: closed` to close a post before expiry. Use `status: draft` only for local review because draft posts do not render.
+`workMode` must be `onsite`, `hybrid`, or `remote`. `employmentType` must be `full-time`, `part-time`, `contract`, `internship`, or `fractional`. Use `employmentTypes` with the same values for a combined post covering multiple roles. Use `status: closed` to close a post before expiry. Use `status: draft` only for local review because draft posts do not render.
 
 ### `presentations`
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,6 +9,7 @@ const optionalUrlOrPath = z.union([
   z.string().regex(/^\/[^\s]*$/, "Use a site-relative path starting with /"),
   z.literal(""),
 ]).optional().default("");
+const jobEmploymentType = z.enum(["full-time", "part-time", "contract", "internship", "fractional"]);
 const personRef = z.object({
   personId: kebabCaseId.optional(),
   name: z.string().optional(),
@@ -104,7 +105,8 @@ const jobs = defineCollection({
     companyUrl: optionalUrl,
     location: z.string(),
     workMode: z.enum(["onsite", "hybrid", "remote"]),
-    employmentType: z.enum(["full-time", "part-time", "contract", "internship", "fractional"]),
+    employmentType: jobEmploymentType.optional(),
+    employmentTypes: z.array(jobEmploymentType).default([]),
     applyUrl: optionalUrl,
     contactEmail: z.email().optional().default(""),
     postedAt: z.coerce.date(),
@@ -114,6 +116,8 @@ const jobs = defineCollection({
     status: z.enum(["open", "closed", "draft"]).default("open"),
   }).refine((job) => job.applyUrl || job.contactEmail, {
     message: "Expected either applyUrl or contactEmail.",
+  }).refine((job) => job.employmentType || job.employmentTypes.length > 0, {
+    message: "Expected employmentType or employmentTypes.",
   }).refine((job) => job.expiresAt >= job.postedAt, {
     message: "expiresAt must be on or after postedAt.",
   }),

--- a/src/content/jobs/founding-research-engineer-data-scorecard.md
+++ b/src/content/jobs/founding-research-engineer-data-scorecard.md
@@ -1,0 +1,80 @@
+---
+title: Research Engineer Roles - AI Training Data
+company: Data Scorecard
+companyUrl: https://datascorecard.ai
+location: Remote or Singapore
+workMode: remote
+employmentTypes:
+  - full-time
+  - internship
+applyUrl: https://datascorecard.ai/careers
+contactEmail: careers@provena.tech
+postedAt: 2026-07-03
+expiresAt: 2026-10-01
+submittedBy:
+  name: Jen Wei Qing
+tags:
+  - ai-training-data
+  - research-engineering
+  - machine-learning
+  - data-curation
+  - internship
+status: open
+---
+
+Data Scorecard is hiring research engineers to build the data infrastructure layer for AI training. Both openings focus on making data curation measurable across pre-training and post-training, then turning successful methods into product features.
+
+## Open roles
+
+- [Founding Research Engineer - AI Training Data](https://datascorecard.ai/careers/founding-research-engineer): a full-time founding role owning data curation as a measured discipline across every stage of training.
+- [Research Engineer Intern - AI Training Data](https://datascorecard.ai/careers/research-engineer-intern): a full-time or part-time internship doing data curation research alongside the founders.
+
+## Founding Research Engineer
+
+- Build metrics for dataset quality, provenance, safety, and coverage that help predict model behaviour.
+- Diagnose data issues such as contamination, uneven multilingual coverage, long-tail gaps, and difficulty mismatches.
+- Design and test curation interventions including pruning, filtering, synthetic augmentation, and relabelling.
+- Turn recent research into practical training and evaluation loops that validate data hypotheses.
+- Ship useful methods as product features and share findings through technical reports or papers.
+
+### What they are looking for
+
+- Strong machine learning and deep-learning fundamentals.
+- Enough software engineering and PyTorch or Jax experience to run ML experiments and build production prototypes.
+- Hands-on experience training or evaluating LLMs or vision-language models.
+- Experience with data curation, pruning and selection, synthetic data, curriculum learning, dataset distillation, or large-scale language or multimodal training.
+- Comfort reading ML research, identifying promising ideas, and implementing them.
+- Ability to drive applied research independently in a fast-moving early-stage environment.
+
+### Nice to have
+
+- Post-training experience such as SFT, preference optimisation, RLVR, or reward modelling.
+- Multilingual or multimodal data work.
+- Multi-GPU or distributed training experience.
+- Open-source or Hugging Face contributions.
+- Public technical writing or published research.
+
+## Research Engineer Intern
+
+- Measure dataset quality, provenance, safety, and coverage metrics that predict downstream model performance.
+- Diagnose where data will hurt a model, including decontamination, difficulty annotation, multilingual asymmetries, and long-tail gaps.
+- Run curation interventions such as filtering, deduplication, and synthetic augmentation, then build eval harnesses to measure their effect.
+- Read recent research, reproduce promising methods, and push them beyond the original paper.
+- Help turn working methods into product features and share findings as a technical report or paper.
+
+### What they are looking for
+
+- Solid Python and working knowledge of the ML stack, including PyTorch or Jax and Hugging Face.
+- Exposure to LLMs or vision-language models through coursework, research, projects, fine-tuning, evaluation, or data pipelines.
+- Comfort reading an ML paper and turning it into a working experiment.
+- Evidence you can build and reason about experiments, such as a repo, paper, project, or competition.
+- Current students, recent grads, and strong self-taught engineers are welcome.
+
+### Nice to have
+
+- Post-training experience such as SFT, preference optimisation, RLVR, or reward modelling.
+- Multilingual or multimodal data work.
+- Synthetic data experience.
+- A shipped side project, tool, or demo people used.
+- Open-source or Hugging Face contributions.
+- Research experience, publications, or technical writing.

--- a/src/pages/jobs/[id].astro
+++ b/src/pages/jobs/[id].astro
@@ -23,6 +23,11 @@ const formatDate = (date: Date) =>
   date.toLocaleDateString("en-SG", { year: "numeric", month: "short", day: "numeric" });
 
 const formatLabel = (value: string) => value.replaceAll("-", " ");
+const formatEmploymentTypes = (job: { data: { employmentType?: string; employmentTypes?: string[] } }) => {
+  const employmentTypes = job.data.employmentTypes ?? [];
+  const types = employmentTypes.length > 0 ? employmentTypes : [job.data.employmentType];
+  return types.filter(Boolean).map((type) => formatLabel(type as string)).join(" / ");
+};
 ---
 
 <BaseLayout
@@ -38,7 +43,7 @@ const formatLabel = (value: string) => value.replaceAll("-", " ");
         <span>{job.data.company}</span>
         <span>{job.data.location}</span>
         <span>{formatLabel(job.data.workMode)}</span>
-        <span>{formatLabel(job.data.employmentType)}</span>
+        <span>{formatEmploymentTypes(job)}</span>
       </div>
       <p>
         Posted {formatDate(job.data.postedAt)}. Expires {formatDate(job.data.expiresAt)}.

--- a/src/pages/jobs/index.astro
+++ b/src/pages/jobs/index.astro
@@ -25,6 +25,11 @@ const formatDate = (date: Date) =>
   date.toLocaleDateString("en-SG", { year: "numeric", month: "short", day: "numeric" });
 
 const formatLabel = (value: string) => value.replaceAll("-", " ");
+const formatEmploymentTypes = (job: { data: { employmentType?: string; employmentTypes?: string[] } }) => {
+  const employmentTypes = job.data.employmentTypes ?? [];
+  const types = employmentTypes.length > 0 ? employmentTypes : [job.data.employmentType];
+  return types.filter(Boolean).map((type) => formatLabel(type as string)).join(" / ");
+};
 ---
 
 <BaseLayout
@@ -53,7 +58,7 @@ const formatLabel = (value: string) => value.replaceAll("-", " ");
                   <span>{job.data.company}</span>
                   <span>{job.data.location}</span>
                   <span>{formatLabel(job.data.workMode)}</span>
-                  <span>{formatLabel(job.data.employmentType)}</span>
+                  <span>{formatEmploymentTypes(job)}</span>
                 </div>
               </div>
               <p>


### PR DESCRIPTION
## What changed

- Added one combined Data Scorecard job post for the Founding Research Engineer and Research Engineer Intern roles.
- Added optional `employmentTypes` support so a single job page can represent multiple employment types.
- Updated the jobs index/detail pages and contributor docs for combined posts.
- Added `yjmbpro` to the local dev allowed hosts alongside `yjmbpro.local`.

## Validation

- `pnpm check`
- `pnpm build`
- Local preview verified at `/jobs/founding-research-engineer-data-scorecard/` with both role sections.