### PR TITLE
Community page: adaptive, searchable, sortable members section

### DIFF
--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -17,7 +17,7 @@ const getAddedAtTime = (value: Date | undefined) => value?.getTime() ?? 0;
 const members = allMembers
   .filter((person) => !orgNames.has(person.data.name))
   .sort((a, b) => {
-    const addedAtDelta = getAddedAtTime(a.data.addedAt) - getAddedAtTime(b.data.addedAt);
+    const addedAtDelta = getAddedAtTime(b.data.addedAt) - getAddedAtTime(a.data.addedAt);
     if (addedAtDelta !== 0) {
       return addedAtDelta;
     }
@@ -94,8 +94,17 @@ const getBackrefGroups = (personId: string): BackrefGroup[] => {
   });
 };
 
+const handleFromUrl = (url: string) => url.split("/").filter(Boolean).pop() ?? "";
+
 const memberSearchText = (person: (typeof members)[number]) =>
-  [person.data.name, ...person.data.aliases, person.data.company, person.data.tagline]
+  [
+    person.data.name,
+    ...person.data.aliases,
+    person.data.company,
+    person.data.tagline,
+    handleFromUrl(person.data.github),
+    handleFromUrl(person.data.twitter),
+  ]
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
@@ -107,7 +116,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
 >
   <h1 class="page-title">Community</h1>
   <p class="collection-guide">
-    A snapshot of our 800+ members as of May 2026. <a class="muted-link" href={contributionLinks.person} target="_blank" rel="noopener">Add yourself on GitHub</a>.
+    800+ members as of May 2026 — {members.length} listed here so far. <a class="muted-link" href={contributionLinks.person} target="_blank" rel="noopener">Add yourself on GitHub</a>.
   </p>
 
   <section>
@@ -140,7 +149,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
                   <div class="person-card-backref-group">
                     <span class="person-card-backref-label">{group.label}</span>
                     {group.items.map((item, index) => (
-                      <a class="person-card-backref-link" href={item.href} title={item.title}>[{index + 1}]</a>
+                      <a class="person-card-backref-link" href={item.href} title={item.title} aria-label={item.title}>[{index + 1}]</a>
                     ))}
                   </div>
                 ))}
@@ -161,18 +170,19 @@ const memberSearchText = (person: (typeof members)[number]) =>
           <input
             type="search"
             data-people-search
-            placeholder="name, company, tagline"
+            placeholder="name, company, handle"
+            title="press / to focus"
             autocomplete="off"
             spellcheck="false"
           />
         </label>
         <div class="people-sort" role="group" aria-labelledby="people-sort-label">
           <span id="people-sort-label">sort:</span>
-          <button type="button" class="sort-option" data-sort="joined" aria-pressed="true" title="Earliest members first">joined</button>
-          <button type="button" class="sort-option" data-sort="newest" aria-pressed="false" title="Most recently added first">newest</button>
+          <button type="button" class="sort-option" data-sort="newest" aria-pressed="true" title="Most recently added first">newest</button>
+          <button type="button" class="sort-option" data-sort="earliest" aria-pressed="false" title="Earliest members first">earliest</button>
           <button type="button" class="sort-option" data-sort="name" aria-pressed="false" title="Alphabetical by name">name</button>
         </div>
-        <span class="people-count" data-people-count aria-live="polite">{members.length} of {members.length} shown</span>
+        <span class="people-count" data-people-count aria-live="polite" hidden></span>
       </div>
     )}
     {members.length > 0 ? (
@@ -191,7 +201,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
               {(person.data.company || person.data.featured) && (
                 <div class="person-card-meta">
                   {person.data.company && <span>{person.data.company}</span>}
-                  {person.data.featured && <span>Featured</span>}
+                  {person.data.featured && <span class="person-card-featured">[featured]</span>}
                 </div>
               )}
             </div>
@@ -205,7 +215,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
                     <div class="person-card-backref-group">
                       <span class="person-card-backref-label">{group.label}</span>
                       {group.items.map((item, index) => (
-                        <a class="person-card-backref-link" href={item.href} title={item.title}>[{index + 1}]</a>
+                        <a class="person-card-backref-link" href={item.href} title={item.title} aria-label={item.title}>[{index + 1}]</a>
                       ))}
                     </div>
                   ))}
@@ -215,7 +225,9 @@ const memberSearchText = (person: (typeof members)[number]) =>
           </div>
         ))}
       </div>
-      <p class="people-empty" data-people-empty hidden>No members match your search.</p>
+      <p class="people-empty" data-people-empty hidden>
+        No members match <span data-people-empty-query></span>. <button type="button" class="sort-option" data-people-clear>clear</button>
+      </p>
       </>
     ) : (
       <p>No members listed yet. <a class="muted-link" href={contributionLinks.person} target="_blank" rel="noopener">Add a person by submitting a pull request</a></p>
@@ -235,13 +247,15 @@ const memberSearchText = (person: (typeof members)[number]) =>
     const countLabel = controls.querySelector<HTMLElement>("[data-people-count]");
     const sortButtons = Array.from(controls.querySelectorAll<HTMLButtonElement>("[data-sort]"));
     const emptyState = document.querySelector<HTMLElement>("[data-people-empty]");
+    const queryEcho = document.querySelector<HTMLElement>("[data-people-empty-query]");
+    const clearButton = document.querySelector<HTMLButtonElement>("[data-people-clear]");
 
     const byName = (a: HTMLElement, b: HTMLElement) =>
       (a.dataset.name ?? "").localeCompare(b.dataset.name ?? "");
     const byAdded = (a: HTMLElement, b: HTMLElement) =>
       Number(a.dataset.added) - Number(b.dataset.added) || byName(a, b);
     const comparators: Record<string, (a: HTMLElement, b: HTMLElement) => number> = {
-      joined: byAdded,
+      earliest: byAdded,
       newest: (a, b) => Number(b.dataset.added) - Number(a.dataset.added) || byName(a, b),
       name: byName,
     };
@@ -256,11 +270,23 @@ const memberSearchText = (person: (typeof members)[number]) =>
         card.hidden = !matches;
         if (matches) shown += 1;
       }
-      if (countLabel) countLabel.textContent = `${shown} of ${cards.length} shown`;
+      if (countLabel) {
+        countLabel.hidden = terms.length === 0;
+        countLabel.textContent = `${shown} of ${cards.length} shown`;
+      }
+      if (queryEcho) queryEcho.textContent = `"${query}"`;
       if (emptyState) emptyState.hidden = shown > 0;
     };
 
+    const clearSearch = () => {
+      if (!searchInput) return;
+      searchInput.value = "";
+      applySearch();
+      searchInput.focus();
+    };
+
     searchInput?.addEventListener("input", applySearch);
+    clearButton?.addEventListener("click", clearSearch);
 
     sortButtons.forEach((button) => {
       button.addEventListener("click", () => {
@@ -283,8 +309,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
         event.preventDefault();
         searchInput.focus();
       } else if (event.key === "Escape" && document.activeElement === searchInput && searchInput.value) {
-        searchInput.value = "";
-        applySearch();
+        clearSearch();
       }
     });
   }
@@ -406,6 +431,10 @@ const memberSearchText = (person: (typeof members)[number]) =>
   .people-empty {
     color: var(--muted);
     margin-top: 16px;
+  }
+
+  .person-card-featured {
+    color: var(--accent);
   }
 
   .person-card-backrefs {

--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -93,6 +93,12 @@ const getBackrefGroups = (personId: string): BackrefGroup[] => {
     return items.length > 0 ? [{ label, items }] : [];
   });
 };
+
+const memberSearchText = (person: (typeof members)[number]) =>
+  [person.data.name, ...person.data.aliases, person.data.company, person.data.tagline]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
 ---
 
 <BaseLayout
@@ -148,10 +154,38 @@ const getBackrefGroups = (personId: string): BackrefGroup[] => {
 
   <section>
     <h3 class="section-label">Members</h3>
+    {members.length > 0 && (
+      <div class="people-controls" data-people-controls hidden>
+        <label class="people-search">
+          <span class="people-search-label">search:</span>
+          <input
+            type="search"
+            data-people-search
+            placeholder="name, company, tagline"
+            autocomplete="off"
+            spellcheck="false"
+          />
+        </label>
+        <div class="people-sort">
+          <span>sort:</span>
+          <button type="button" class="sort-option" data-sort="joined" aria-pressed="true" title="Earliest members first">joined</button>
+          <button type="button" class="sort-option" data-sort="newest" aria-pressed="false" title="Most recently added first">newest</button>
+          <button type="button" class="sort-option" data-sort="name" aria-pressed="false" title="Alphabetical by name">name</button>
+        </div>
+        <span class="people-count" data-people-count aria-live="polite">{members.length} of {members.length} shown</span>
+      </div>
+    )}
     {members.length > 0 ? (
-      <div class="grid columns-2">
+      <>
+      <div class="grid people-grid" id="members-grid">
         {members.map((person) => (
-          <div class="person-card" id={person.data.id}>
+          <div
+            class="person-card"
+            id={person.data.id}
+            data-search={memberSearchText(person)}
+            data-name={person.data.name.toLowerCase()}
+            data-added={getAddedAtTime(person.data.addedAt)}
+          >
             <div class="person-card-header">
               <span class="person-card-title">{person.data.name}</span>
               {(person.data.company || person.data.featured) && (
@@ -181,13 +215,185 @@ const getBackrefGroups = (personId: string): BackrefGroup[] => {
           </div>
         ))}
       </div>
+      <p class="people-empty" data-people-empty hidden>No members match your search.</p>
+      </>
     ) : (
       <p>No members listed yet. <a class="muted-link" href={contributionLinks.person} target="_blank" rel="noopener">Add a person by submitting a pull request</a></p>
     )}
   </section>
 </BaseLayout>
 
+<script>
+  const controls = document.querySelector<HTMLElement>("[data-people-controls]");
+  const grid = document.getElementById("members-grid");
+
+  if (controls && grid) {
+    controls.hidden = false;
+
+    const cards = Array.from(grid.querySelectorAll<HTMLElement>("[data-search]"));
+    const searchInput = controls.querySelector<HTMLInputElement>("[data-people-search]");
+    const countLabel = controls.querySelector<HTMLElement>("[data-people-count]");
+    const sortButtons = Array.from(controls.querySelectorAll<HTMLButtonElement>("[data-sort]"));
+    const emptyState = document.querySelector<HTMLElement>("[data-people-empty]");
+
+    const byName = (a: HTMLElement, b: HTMLElement) =>
+      (a.dataset.name ?? "").localeCompare(b.dataset.name ?? "");
+    const byAdded = (a: HTMLElement, b: HTMLElement) =>
+      Number(a.dataset.added) - Number(b.dataset.added) || byName(a, b);
+    const comparators: Record<string, (a: HTMLElement, b: HTMLElement) => number> = {
+      joined: byAdded,
+      newest: (a, b) => Number(b.dataset.added) - Number(a.dataset.added) || byName(a, b),
+      name: byName,
+    };
+
+    const applySearch = () => {
+      const query = (searchInput?.value ?? "").trim().toLowerCase();
+      let shown = 0;
+      for (const card of cards) {
+        const matches = query === "" || (card.dataset.search ?? "").includes(query);
+        card.hidden = !matches;
+        if (matches) shown += 1;
+      }
+      if (countLabel) countLabel.textContent = `${shown} of ${cards.length} shown`;
+      if (emptyState) emptyState.hidden = shown > 0;
+    };
+
+    searchInput?.addEventListener("input", applySearch);
+
+    sortButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const comparator = comparators[button.dataset.sort ?? ""];
+        if (!comparator) return;
+        sortButtons.forEach((other) => other.setAttribute("aria-pressed", String(other === button)));
+        cards.sort(comparator).forEach((card) => grid.appendChild(card));
+      });
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (!searchInput) return;
+      const target = event.target as HTMLElement | null;
+      const isTyping =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        Boolean(target?.isContentEditable);
+
+      if (event.key === "/" && !isTyping) {
+        event.preventDefault();
+        searchInput.focus();
+      } else if (event.key === "Escape" && document.activeElement === searchInput && searchInput.value) {
+        searchInput.value = "";
+        applySearch();
+      }
+    });
+  }
+</script>
+
 <style>
+  .people-controls {
+    align-items: baseline;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 20px;
+    margin-bottom: 16px;
+  }
+
+  .people-controls[hidden] {
+    display: none;
+  }
+
+  .people-search {
+    align-items: baseline;
+    display: flex;
+    flex: 1 1 240px;
+    gap: 8px;
+  }
+
+  .people-search-label {
+    color: var(--muted);
+    font-size: 1rem;
+  }
+
+  .people-search input {
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--line);
+    color: var(--text);
+    flex: 1;
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    min-width: 120px;
+    outline: none;
+    padding: 2px 0;
+  }
+
+  .people-search input:focus {
+    border-bottom-color: var(--accent);
+  }
+
+  .people-search input::placeholder {
+    color: var(--muted);
+    opacity: 0.6;
+  }
+
+  .people-sort {
+    align-items: baseline;
+    color: var(--muted);
+    display: flex;
+    flex-wrap: wrap;
+    font-size: 1rem;
+    gap: 6px;
+  }
+
+  .sort-option {
+    background: none;
+    border: none;
+    color: var(--muted);
+    cursor: pointer;
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    padding: 0;
+  }
+
+  .sort-option::before {
+    content: "[";
+    opacity: 0.6;
+  }
+
+  .sort-option::after {
+    content: "]";
+    opacity: 0.6;
+  }
+
+  .sort-option:hover,
+  .sort-option:focus-visible {
+    text-decoration: underline;
+  }
+
+  .sort-option[aria-pressed="true"] {
+    color: var(--accent);
+    font-weight: 700;
+  }
+
+  .people-count {
+    color: var(--muted);
+    font-size: 1rem;
+    margin-left: auto;
+    opacity: 0.8;
+  }
+
+  .people-grid {
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  }
+
+  .person-card[hidden] {
+    display: none;
+  }
+
+  .people-empty {
+    color: var(--muted);
+    margin-top: 16px;
+  }
+
   .person-card-backrefs {
     color: var(--muted);
     display: grid;

--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -152,7 +152,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
     </div>
   </section>
 
-  <section>
+  <section class="members-section">
     <h3 class="section-label">Members</h3>
     {members.length > 0 && (
       <div class="people-controls" data-people-controls hidden>
@@ -289,6 +289,12 @@ const memberSearchText = (person: (typeof members)[number]) =>
 </script>
 
 <style>
+  .members-section {
+    --members-width: min(1200px, calc(100vw - 48px));
+    margin-inline: calc((100% - var(--members-width)) / 2);
+    width: var(--members-width);
+  }
+
   .people-controls {
     align-items: baseline;
     display: flex;

--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -182,7 +182,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
           <button type="button" class="sort-option" data-sort="earliest" aria-pressed="false" title="Earliest members first">earliest</button>
           <button type="button" class="sort-option" data-sort="name" aria-pressed="false" title="Alphabetical by name">name</button>
         </div>
-        <span class="people-count" data-people-count aria-live="polite" hidden></span>
+        <span class="people-count" data-people-count aria-live="polite" data-idle>{members.length} of {members.length} shown</span>
       </div>
     )}
     {members.length > 0 ? (
@@ -201,7 +201,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
               {(person.data.company || person.data.featured) && (
                 <div class="person-card-meta">
                   {person.data.company && <span>{person.data.company}</span>}
-                  {person.data.featured && <span class="person-card-featured">[featured]</span>}
+                  {person.data.featured && <span class="person-card-featured">featured</span>}
                 </div>
               )}
             </div>
@@ -271,10 +271,13 @@ const memberSearchText = (person: (typeof members)[number]) =>
         if (matches) shown += 1;
       }
       if (countLabel) {
-        countLabel.hidden = terms.length === 0;
+        countLabel.toggleAttribute("data-idle", terms.length === 0);
         countLabel.textContent = `${shown} of ${cards.length} shown`;
       }
-      if (queryEcho) queryEcho.textContent = `"${query}"`;
+      if (queryEcho) {
+        const display = query.length > 60 ? `${query.slice(0, 60)}…` : query;
+        queryEcho.textContent = `"${display}"`;
+      }
       if (emptyState) emptyState.hidden = shown > 0;
     };
 
@@ -298,7 +301,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
     });
 
     document.addEventListener("keydown", (event) => {
-      if (!searchInput) return;
+      if (!searchInput || event.isComposing) return;
       const target = event.target as HTMLElement | null;
       const isTyping =
         target instanceof HTMLInputElement ||
@@ -413,11 +416,19 @@ const memberSearchText = (person: (typeof members)[number]) =>
     font-weight: 700;
   }
 
+  /* reserve the counter's row space even while idle so the controls row
+     doesn't reflow on the first keystroke of a filter */
   .people-count {
     color: var(--muted);
     font-size: 1rem;
     margin-left: auto;
+    min-width: 14ch;
     opacity: 0.8;
+    text-align: right;
+  }
+
+  .people-count[data-idle] {
+    visibility: hidden;
   }
 
   .people-grid {
@@ -431,10 +442,21 @@ const memberSearchText = (person: (typeof members)[number]) =>
   .people-empty {
     color: var(--muted);
     margin-top: 16px;
+    overflow-wrap: anywhere;
   }
 
   .person-card-featured {
     color: var(--accent);
+  }
+
+  .person-card-meta .person-card-featured::before {
+    content: "[" / "";
+    opacity: 0.6;
+  }
+
+  .person-card-meta .person-card-featured::after {
+    content: "]" / "";
+    opacity: 0.6;
   }
 
   .person-card-backrefs {

--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -166,8 +166,8 @@ const memberSearchText = (person: (typeof members)[number]) =>
             spellcheck="false"
           />
         </label>
-        <div class="people-sort">
-          <span>sort:</span>
+        <div class="people-sort" role="group" aria-labelledby="people-sort-label">
+          <span id="people-sort-label">sort:</span>
           <button type="button" class="sort-option" data-sort="joined" aria-pressed="true" title="Earliest members first">joined</button>
           <button type="button" class="sort-option" data-sort="newest" aria-pressed="false" title="Most recently added first">newest</button>
           <button type="button" class="sort-option" data-sort="name" aria-pressed="false" title="Alphabetical by name">name</button>
@@ -248,9 +248,11 @@ const memberSearchText = (person: (typeof members)[number]) =>
 
     const applySearch = () => {
       const query = (searchInput?.value ?? "").trim().toLowerCase();
+      const terms = query.split(/\s+/).filter(Boolean);
       let shown = 0;
       for (const card of cards) {
-        const matches = query === "" || (card.dataset.search ?? "").includes(query);
+        const haystack = card.dataset.search ?? "";
+        const matches = terms.every((term) => haystack.includes(term));
         card.hidden = !matches;
         if (matches) shown += 1;
       }
@@ -277,7 +279,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
         target instanceof HTMLTextAreaElement ||
         Boolean(target?.isContentEditable);
 
-      if (event.key === "/" && !isTyping) {
+      if (event.key === "/" && !isTyping && !event.ctrlKey && !event.metaKey && !event.altKey) {
         event.preventDefault();
         searchInput.focus();
       } else if (event.key === "Escape" && document.activeElement === searchInput && searchInput.value) {
@@ -290,7 +292,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
 
 <style>
   .members-section {
-    --members-width: min(1200px, calc(100vw - 48px));
+    --members-width: max(100%, min(1200px, calc(100vw - 40px)));
     margin-inline: calc((100% - var(--members-width)) / 2);
     width: var(--members-width);
   }
@@ -322,7 +324,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
   .people-search input {
     background: transparent;
     border: none;
-    border-bottom: 1px solid var(--line);
+    border-bottom: 1px solid rgba(174, 201, 244, 0.45);
     color: var(--text);
     flex: 1;
     font-family: var(--font-sans);
@@ -338,7 +340,7 @@ const memberSearchText = (person: (typeof members)[number]) =>
 
   .people-search input::placeholder {
     color: var(--muted);
-    opacity: 0.6;
+    opacity: 0.65;
   }
 
   .people-sort {
@@ -357,22 +359,28 @@ const memberSearchText = (person: (typeof members)[number]) =>
     cursor: pointer;
     font-family: var(--font-sans);
     font-size: 1rem;
-    padding: 0;
+    padding: 4px 0;
   }
 
+  /* the "/ ''" alternative text keeps brackets out of accessible names */
   .sort-option::before {
-    content: "[";
+    content: "[" / "";
     opacity: 0.6;
   }
 
   .sort-option::after {
-    content: "]";
+    content: "]" / "";
     opacity: 0.6;
   }
 
   .sort-option:hover,
   .sort-option:focus-visible {
     text-decoration: underline;
+  }
+
+  .sort-option:focus-visible {
+    box-shadow: var(--focus-ring);
+    outline: none;
   }
 
   .sort-option[aria-pressed="true"] {


### PR DESCRIPTION
## Summary

The Organisers section keeps its fixed two-column (2×2) grid; the Members section gets a denser, adaptive layout with client-side search and sort, all in a single file (`src/pages/community/index.astro`).

- **Adaptive layout**: members switch from the fixed 2-column grid to `repeat(auto-fill, minmax(240px, 1fr))`, and the section breaks out of the 800px shell up to `max(100%, min(1200px, 100vw - 40px))` — 3 columns at the shell width, 4 on wide screens, 1 on mobile, never narrower than the shell.
- **Search**: terminal-styled `search:` input live-filters on name, aliases, company, tagline, and GitHub/X handles (tokenized, order-independent AND match). `/` focuses the input (ignoring modifier chords and IME composition), Escape clears. Empty state echoes the query (wrapped and capped at 60 chars) with a bracket-styled `[clear]` button.
- **Sort**: `sort: [newest] [earliest] [name]` bracket toggles; newest-first is the default (server-rendered order matches, so the initial click is a no-op) and ties break alphabetically.
- **Copy**: intro reads "800+ members as of May 2026 — {n} listed here so far", and the "N of M shown" counter only becomes visible while a filter is active (its space stays reserved so the controls row never reflows mid-typing).
- **Accessibility**: sort buttons use the site focus-ring token, expose bracket-free accessible names via `content: "[" / ""`, sit in a labelled `role=group`, and meet 24px target height; placeholder and input-underline contrast raised to WCAG levels; backref links carry `aria-label`s; controls ship `hidden` so the no-JS page renders the full list unchanged.

## Review process

Built-in stages: an initial five-lens design review (visual consistency, responsive layout, interaction UX, accessibility, information design) against the live built page, followed by a three-agent adversarial pass (functional breaker, code skeptic, design-rules auditor). All confirmed findings are fixed in the branch — notably the mobile breakout inset, order-dependent multi-word search, the counter-appearance layout jump, query-echo overflow, and the IME Escape wipe.

## Testing

- `pnpm check` and `pnpm build` pass.
- Headless Chromium verification of the built site: alignment with the organisers grid at 375/640/800px (delta 0), 3/4/1 columns at 800/1440/375px, zero horizontal overflow at 22 viewport widths (including a 500-char search token), sort orders validated against `members.yaml` ground truth including `addedAt` ties, controls-row geometry byte-stable across filter start/stop, XSS-safe query echo, and full-list rendering with JavaScript disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKbe1csGBDYdWkk95NNmJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKbe1csGBDYdWkk95NNmJo)_