### PR TITLE
Add Local LLMs meetup at AmChamSG

### DIFF
--- a/src/content/events/2026-08-11-abc-local-llms-at-amcham.md
+++ b/src/content/events/2026-08-11-abc-local-llms-at-amcham.md
@@ -1,0 +1,23 @@
+---
+title: "#9 - ABC Local LLMs at AmChamSG"
+date: 2026-08-11
+kind: "meetup"
+time: "6:00 PM – 9:00 PM SGT"
+venue: "AmChamSG @ Shaw Centre"
+venueUrl: "https://maps.app.goo.gl/?q=1+Scotts+Rd+Shaw+Centre+Singapore+228208"
+sponsorName: ""
+sponsorUrl: ""
+registrationUrl: "https://luma.com/yra2b4ub"
+attendance: 0
+speakers: []
+hosts:
+  - personId: "chris-pecaut"
+  - personId: "ian-choo"
+  - personId: "jensen-loke"
+  - personId: "yj-soon"
+tags: ["meetup", "local-llms", "agentic-coding"]
+status: "upcoming"
+---
+Join fellow builders for an evening focused on running local LLMs on your own hardware, with practical tips, applied presentations, hands-on building, and time to connect with Singapore's agentic coding community.
+
+Featured hardware includes a Mac Studio M3 Ultra, MacBook Pro M5 Max, NVIDIA DGX Spark, and NVIDIA RTX PRO 5000, alongside tools such as Claude, Codex, Gemini, OpenClaw, and Qwen.


### PR DESCRIPTION
## Summary

- add the 11 August 2026 ABC Local LLMs meetup at AmChamSG
- link the Luma registration page and current ABC organisers
- make the collection-driven homepage feature the new upcoming meetup

## Impact

Visitors can discover and register for meetup #9 from the homepage, Events page, and Calendar page.

## Validation

- pnpm check
- pnpm build