### PR TITLE
docs: derive production tags from origin

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,14 +27,18 @@ After the release commit is merged to `main`, create and push the next version t
 ```sh
 git switch main
 git pull --ff-only origin main
-git tag v1.0.40
-git push origin v1.0.40
+next_tag="$(corepack pnpm run --silent next-release-tag)"
+git tag "$next_tag"
+git push origin "$next_tag"
 ```
 
-Replace `v1.0.40` with the next appropriate `v*` version for the repo state. Check the latest existing tag before tagging:
+`next-release-tag` queries tags from `origin`, finds the highest stable `vMAJOR.MINOR.PATCH` tag, and increments the patch version. For an intentional minor or major release, pass the bump explicitly:
 
 ```sh
-git tag --sort=-version:refname | head -5
+next_tag="$(corepack pnpm run --silent next-release-tag -- minor)"
+# or: corepack pnpm run --silent next-release-tag -- major
+git tag "$next_tag"
+git push origin "$next_tag"
 ```
 
 ## Production notification

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "astro": "astro"
+    "astro": "astro",
+    "next-release-tag": "node scripts/next-release-tag.mjs"
   },
   "dependencies": {
     "astro": "^6.0.8",

--- a/scripts/next-release-tag.mjs
+++ b/scripts/next-release-tag.mjs
@@ -1,0 +1,49 @@
+import { execFileSync } from 'node:child_process';
+
+const cliArgs = process.argv.slice(2).filter((argument) => argument !== '--');
+const bump = cliArgs[0] ?? 'patch';
+
+if (!['patch', 'minor', 'major'].includes(bump) || cliArgs.length > 1) {
+  console.error('Usage: node scripts/next-release-tag.mjs [patch|minor|major]');
+  process.exit(1);
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' });
+}
+
+// Tags on origin are the release source of truth, not the local checkout's tag set.
+const remoteTags = git(['ls-remote', '--tags', '--refs', 'origin']);
+
+const versionPattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const versions = remoteTags
+  .split('\n')
+  .flatMap((line) => {
+    const [, ref] = line.split('\t');
+    const tag = ref?.replace('refs/tags/', '');
+    const match = tag?.match(versionPattern);
+    return match ? [{ tag, parts: match.slice(1).map(Number) }] : [];
+  })
+  .sort((left, right) => {
+    for (let index = 0; index < left.parts.length; index += 1) {
+      if (left.parts[index] !== right.parts[index]) {
+        return right.parts[index] - left.parts[index];
+      }
+    }
+    return 0;
+  });
+
+if (versions.length === 0) {
+  console.error('No stable vMAJOR.MINOR.PATCH tags found on origin. Create the initial tag manually.');
+  process.exit(1);
+}
+
+const [major, minor, patch] = versions[0].parts;
+const next =
+  bump === 'major'
+    ? [major + 1, 0, 0]
+    : bump === 'minor'
+      ? [major, minor + 1, 0]
+      : [major, minor, patch + 1];
+
+process.stdout.write(`v${next.join('.')}\n`);


### PR DESCRIPTION
## What changed
- Added a `next-release-tag` command that reads stable release tags directly from `origin`.
- Updated the production deployment guide to capture and push the computed tag.
- Added explicit minor and major bump options.

## Why
The old guide embedded a sample tag that became stale after every release.

## Validation
- `corepack pnpm run --silent next-release-tag` -> `v1.0.44`
- `corepack pnpm run --silent next-release-tag -- minor` -> `v1.1.0`
- `corepack pnpm run --silent next-release-tag -- major` -> `v2.0.0`
- `corepack pnpm check`
- `corepack pnpm build`