### PR TITLE
Add Tencent Cloud agent development challenge

### DIFF
--- a/src/content/events/2026-08-14-ai-tinkerers-tencent-cloud-agent-development-challenge.md
+++ b/src/content/events/2026-08-14-ai-tinkerers-tencent-cloud-agent-development-challenge.md
@@ -1,0 +1,19 @@
+---
+title: "AI Tinkerers x Tencent Cloud Hackathon: Agent Development Challenge"
+date: 2026-08-14
+kind: "external"
+time: "Submissions close at 6:00 PM SGT"
+venue: "Online; Singapore Demo Day on 22 Aug (tentative)"
+venueUrl: ""
+registrationUrl: "https://luma.com/jo916m7a"
+attendance: 0
+speakers: []
+hosts:
+  - name: "AI Tinkerers Singapore"
+  - name: "Tencent Cloud"
+tags: ["hackathon", "ai-agents", "tencent-cloud", "ai-tinkerers"]
+status: "upcoming"
+---
+AI Tinkerers Singapore and Tencent Cloud invite Singapore-based builders to ship an AI agent using WorkBuddy or CodeBuddy. Enter solo or in a team of up to three, choose a Productivity, Business, or Life Agent track, and receive 2,000 product credits to build from 22 July to 14 August.
+
+Projects are due on 14 August at 6:00 PM SGT, followed by a tentative in-person Singapore Demo Day on 22 August. Top teams can win SGD 3,000, SGD 2,000, or SGD 1,000, and Singapore's top three teams receive funded travel to Shenzhen for the global final in September.


### PR DESCRIPTION
## Summary

- list the AI Tinkerers Singapore x Tencent Cloud Agent Development Challenge as an external event
- link registration to the current Luma page
- include the submission deadline, tentative Singapore Demo Day, team format, prizes, and Shenzhen global-final pathway

## Why

This gives Agentic Builders Collective members a direct way to discover and register for the Singapore hackathon.

## Validation

- `corepack pnpm check` — 0 errors
- `corepack pnpm build` — 16 pages built successfully