### PR TITLE
Add code riff episode with Roger Olofsson to articles

### DIFF
--- a/src/content/articles/articles.yaml
+++ b/src/content/articles/articles.yaml
@@ -39,7 +39,7 @@
     - ai
     - podcast
 - id: code-riff-roger-olofsson-ai-native-recruiting
-  title: "Inside an AI-native recruiting firm's stack | Roger Olofsson (Co-Founder of Olofsson Consulting)"
+  title: "Inside an AI-native recruiting firm's stack | Roger Olofsson (CEO & Co-Founder of Olofsson & Co)"
   authors:
     - personId: eric-tan
     - personId: yaohong-chng

--- a/src/content/articles/articles.yaml
+++ b/src/content/articles/articles.yaml
@@ -38,3 +38,18 @@
     - cybersecurity
     - ai
     - podcast
+- id: code-riff-roger-olofsson-ai-native-recruiting
+  title: "Inside an AI-native recruiting firm's stack | Roger Olofsson (Co-Founder of Olofsson Consulting)"
+  authors:
+    - personId: eric-tan
+    - personId: yaohong-chng
+  url: https://www.youtube.com/watch?v=80-kHxd3gyA
+  publication: code riff
+  date: 2026-07-20
+  summary: a code riff conversation with Roger Olofsson, CEO and Co-Founder of Olofsson Consulting, on running an ai-native executive search firm. includes a live walkthrough of the matching platform his team built across 395,000 candidates, why the whole firm now works in claude code after building their own software, the new roles ai created including an agentic product manager, and the promise he made his team that nobody would lose their job.
+  tags:
+    - recruitment
+    - claude-code
+    - agents
+    - ai
+    - podcast


### PR DESCRIPTION
Adds one entry to `src/content/articles/articles.yaml` for a code riff episode with Roger Olofsson, CEO and Co-Founder of Olofsson Consulting, an AI-native executive search firm in Singapore. He walks through the matching platform his team built, and why the whole firm works in Claude Code.

Follows `docs/add-article.md`. Both authors (`eric-tan`, `yaohong-chng`) are existing members, so the `personId` references resolve. Same shape as the existing `code-riff-gaurav-keerthi-cybersecurity` entry.

Change is additive only, no unrelated entries reformatted.

`pnpm check` (0 errors, 0 warnings) and `pnpm build` (16 pages) both pass locally.