### PR TITLE
Add public-submittal sharing policy notification

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/job-post.md
+++ b/.github/PULL_REQUEST_TEMPLATE/job-post.md
@@ -9,6 +9,10 @@
 - [ ] `pnpm check` passes.
 - [ ] `pnpm build` passes.
 
+## Sharing policy
+
+Outside Sharing Sundays, the only permitted share for an accepted job post is the relevant link on [agenticbuilders.sg](https://agenticbuilders.sg/). Do not share the external company or application link, screenshots, copied promotional text, or repeated reposts outside Sharing Sundays.
+
 ## Admin Review
 
 - [ ] Approved for publication on the Agentic Builders Collective website.

--- a/.github/PULL_REQUEST_TEMPLATE/public-submittal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/public-submittal.md
@@ -1,0 +1,17 @@
+## Public-submittal checklist
+
+- [ ] This PR adds or updates a public event, presentation, project, article, member profile, or job post.
+- [ ] The relevant collection guide and `docs/id-guidelines.md` have been followed.
+- [ ] `pnpm check` passes.
+- [ ] `pnpm build` passes.
+
+## Sharing policy
+
+Outside Sharing Sundays, the only permitted share for an accepted submission is the relevant link on [agenticbuilders.sg](https://agenticbuilders.sg/).
+
+- [ ] I understand that I should not share the external event, project, article, registration, or company URL outside Sharing Sundays.
+- [ ] I understand that screenshots, copied promotional text, and repeated reposts are not substitutes for the ABC page link outside Sharing Sundays.
+
+## Admin review
+
+- [ ] Approved for publication on the Agentic Builders Collective website.

--- a/.github/workflows/public-submittal-sharing-policy-notify.yml
+++ b/.github/workflows/public-submittal-sharing-policy-notify.yml
@@ -1,0 +1,193 @@
+name: Public-submittal sharing policy notifier
+
+on:
+  workflow_run:
+    workflows: ["Public-submittal sharing policy trigger"]
+    types: [completed]
+
+permissions:
+  actions: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: public-submittal-sharing-policy-notifier
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request_review'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Find pull request identity artifact
+        id: artifact
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner,
+              repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const artifact = data.artifacts.find(({ name, expired }) =>
+              name === "public-submittal-policy-pr" && !expired,
+            );
+            core.setOutput("available", String(Boolean(artifact)));
+      - name: Download pull request identity artifact
+        if: steps.artifact.outputs.available == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: public-submittal-policy-pr
+          path: policy-trigger
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read pull request identity
+        if: steps.artifact.outputs.available == 'true'
+        id: pull-request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("node:fs");
+            const value = fs.readFileSync("policy-trigger/pull-request-number.txt", "utf8").trim();
+            if (!/^\d+$/.test(value)) {
+              core.setFailed("The pull request identity artifact was invalid.");
+              return;
+            }
+            core.setOutput("number", value);
+      - name: Post sharing policy to the pull request
+        if: steps.pull-request.outputs.number != ''
+        uses: actions/github-script@v7
+        env:
+          PULL_REQUEST_NUMBER: ${{ steps.pull-request.outputs.number }}
+          SITE_BASE_URL: https://agenticbuilders.sg
+          POLICY_MARKER: abc-public-submittal-sharing-policy-v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = Number(process.env.PULL_REQUEST_NUMBER);
+            const workflowRun = context.payload.workflow_run;
+            const expectedHeadRepository = workflowRun.head_repository?.full_name;
+            const expectedHeadBranch = workflowRun.head_branch;
+            const expectedMergeSha = workflowRun.head_sha;
+            const siteBaseUrl = process.env.SITE_BASE_URL;
+            const policyMarker = process.env.POLICY_MARKER;
+            const publicPathPrefixes = [
+              "src/content/events/",
+              "src/content/projects/",
+              "src/content/articles/",
+              "src/content/presentations/",
+              "src/content/members/",
+              "src/content/jobs/",
+            ];
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+            if (pullRequest.state !== "open") {
+              core.info("The pull request is no longer open.");
+              return;
+            }
+            if (
+              !expectedHeadRepository ||
+              !expectedHeadBranch ||
+              !expectedMergeSha ||
+              pullRequest.head.repo?.full_name !== expectedHeadRepository ||
+              pullRequest.head.ref !== expectedHeadBranch ||
+              pullRequest.merge_commit_sha !== expectedMergeSha
+            ) {
+              core.setFailed("The pull request identity artifact did not match the triggering workflow run.");
+              return;
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+            const latestReviewByUser = new Map();
+            for (const review of reviews) {
+              if (review.user?.login) latestReviewByUser.set(review.user.login, review);
+            }
+            const approvedReviewers = [...latestReviewByUser.values()]
+              .filter((review) => review.state === "APPROVED")
+              .filter((review) => review.user?.login && review.user.login !== pullRequest.user?.login);
+            const permissionLevels = await Promise.all(approvedReviewers.map(async (review) => {
+              const login = review.user.login;
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username: login });
+              return data.permission;
+            }));
+            if (!permissionLevels.some((permission) => ["admin", "maintain", "write"].includes(permission))) {
+              core.info("No current approval from a repository maintainer was found.");
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+            const publicFiles = files.filter(({ filename, status }) =>
+              status !== "removed" && publicPathPrefixes.some((prefix) => filename.startsWith(prefix)),
+            );
+            if (publicFiles.length === 0) {
+              core.info("This pull request does not add or update a public-submittal collection.");
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pullNumber,
+              per_page: 100,
+            });
+            if (comments.some(({ body = "", user }) => user?.login === "github-actions[bot]" && body.includes(policyMarker))) {
+              core.info("The public-submittal sharing policy has already been posted.");
+              return;
+            }
+
+            const pageUrls = new Set();
+            for (const { filename } of publicFiles) {
+              const relativePath = filename.replaceAll("\\", "/");
+              const fileName = relativePath.split("/").pop() ?? "";
+              const id = fileName.replace(/\.md$/, "");
+              if (relativePath.startsWith("src/content/events/") && id) {
+                pageUrls.add(`${siteBaseUrl}/events/#${id}`);
+              } else if (relativePath.startsWith("src/content/projects/") && id) {
+                pageUrls.add(`${siteBaseUrl}/showcase/#${id}`);
+              } else if (relativePath.startsWith("src/content/jobs/") && id) {
+                pageUrls.add(`${siteBaseUrl}/jobs/${id}/`);
+              } else if (relativePath.startsWith("src/content/articles/")) {
+                pageUrls.add(`${siteBaseUrl}/showcase/#articles`);
+              } else if (relativePath.startsWith("src/content/presentations/")) {
+                pageUrls.add(`${siteBaseUrl}/showcase/#presentations`);
+              } else if (relativePath.startsWith("src/content/members/")) {
+                pageUrls.add(`${siteBaseUrl}/community/`);
+              }
+            }
+            const links = [...pageUrls].map((url) => `- [${url}](${url})`).join("\n");
+            const contributor = pullRequest.user?.login ?? "contributor";
+            const body = [
+              `<!-- ${policyMarker} -->`,
+              `Thanks @${contributor} — this public-submittal pull request has been approved by a maintainer.`,
+              "",
+              "**Sharing policy:** Outside Sharing Sundays, the only permitted share for this accepted submission is the relevant link on `agenticbuilders.sg`.",
+              "",
+              "Please do not share the external event, project, article, registration, or company URL, screenshots, copied promotional text, or repeated reposts outside Sharing Sundays. The external links needed for the listing may still appear on the ABC page itself.",
+              "",
+              "After the submission is published, use the relevant ABC page link:",
+              links,
+              "",
+              "The site page is the permitted off-day share; general promotional sharing remains reserved for Sharing Sundays.",
+            ].join("\n");
+            await github.rest.issues.createComment({ owner, repo, issue_number: pullNumber, body });

--- a/.github/workflows/public-submittal-sharing-policy.yml
+++ b/.github/workflows/public-submittal-sharing-policy.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: read
 
 jobs:
   notify:

--- a/.github/workflows/public-submittal-sharing-policy.yml
+++ b/.github/workflows/public-submittal-sharing-policy.yml
@@ -1,0 +1,117 @@
+name: Public-submittal sharing policy
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  notify:
+    name: Notify approved public submittal
+    if: >-
+      github.event.review.state == 'approved' &&
+      contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post sharing policy to the pull request
+        uses: actions/github-script@v7
+        env:
+          SITE_BASE_URL: https://agenticbuilders.sg
+          POLICY_MARKER: abc-public-submittal-sharing-policy-v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = context.payload.pull_request.number;
+            const siteBaseUrl = process.env.SITE_BASE_URL;
+            const policyMarker = process.env.POLICY_MARKER;
+            const publicPathPrefixes = [
+              "src/content/events/",
+              "src/content/projects/",
+              "src/content/articles/",
+              "src/content/presentations/",
+              "src/content/members/",
+              "src/content/jobs/",
+            ];
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+
+            const publicFiles = files.filter(({ filename }) =>
+              publicPathPrefixes.some((prefix) => filename.startsWith(prefix)),
+            );
+
+            if (publicFiles.length === 0) {
+              core.info("This pull request does not change a public-submittal collection.");
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pullNumber,
+              per_page: 100,
+            });
+
+            if (comments.some(({ body = "" }) => body.includes(policyMarker))) {
+              core.info("The public-submittal sharing policy has already been posted.");
+              return;
+            }
+
+            const pageUrls = new Set();
+            for (const { filename } of publicFiles) {
+              const relativePath = filename.replaceAll("\\", "/");
+              const fileName = relativePath.split("/").pop() ?? "";
+              const id = fileName.replace(/\.md$/, "");
+
+              if (relativePath.startsWith("src/content/events/") && id) {
+                pageUrls.add(`${siteBaseUrl}/events/#${id}`);
+              } else if (relativePath.startsWith("src/content/projects/") && id) {
+                pageUrls.add(`${siteBaseUrl}/showcase/#${id}`);
+              } else if (relativePath.startsWith("src/content/jobs/") && id) {
+                pageUrls.add(`${siteBaseUrl}/jobs/${id}/`);
+              } else if (relativePath.startsWith("src/content/articles/")) {
+                pageUrls.add(`${siteBaseUrl}/showcase/#articles`);
+              } else if (relativePath.startsWith("src/content/presentations/")) {
+                pageUrls.add(`${siteBaseUrl}/showcase/#presentations`);
+              } else if (relativePath.startsWith("src/content/members/")) {
+                pageUrls.add(`${siteBaseUrl}/community/`);
+              }
+            }
+
+            if (pageUrls.size === 0) {
+              pageUrls.add(`${siteBaseUrl}/`);
+            }
+
+            const links = [...pageUrls]
+              .map((url) => `- [${url}](${url})`)
+              .join("\n");
+            const contributor = context.payload.pull_request.user.login;
+            const body = [
+              `<!-- ${policyMarker} -->`,
+              `Thanks @${contributor} — this public-submittal pull request has been approved by a maintainer.`,
+              "",
+              "**Sharing policy:** Outside Sharing Sundays, the only permitted share for this accepted submission is the relevant link on `agenticbuilders.sg`.",
+              "",
+              "Please do not share the external event, project, article, registration, or company URL, screenshots, copied promotional text, or repeated reposts outside Sharing Sundays. The external links needed for the listing may still appear on the ABC page itself.",
+              "",
+              "After the submission is published, use the relevant ABC page link:",
+              links,
+              "",
+              "The site page is the permitted off-day share; general promotional sharing remains reserved for Sharing Sundays.",
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pullNumber,
+              body,
+            });

--- a/.github/workflows/public-submittal-sharing-policy.yml
+++ b/.github/workflows/public-submittal-sharing-policy.yml
@@ -1,118 +1,25 @@
-name: Public-submittal sharing policy
+name: Public-submittal sharing policy trigger
 
 on:
   pull_request_review:
     types: [submitted]
 
 permissions:
-  contents: read
-  issues: write
-  pull-requests: read
+  {}
 
 jobs:
-  notify:
-    name: Notify approved public submittal
-    if: >-
-      github.event.review.state == 'approved' &&
-      contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+  approved:
+    name: Observe approved public submittal review
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Post sharing policy to the pull request
-        uses: actions/github-script@v7
-        env:
-          SITE_BASE_URL: https://agenticbuilders.sg
-          POLICY_MARKER: abc-public-submittal-sharing-policy-v1
+      - name: Store pull request identity for the trusted notifier
+        run: echo "${{ github.event.pull_request.number }}" > pull-request-number.txt
+      - name: Upload pull request identity
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { owner, repo } = context.repo;
-            const pullNumber = context.payload.pull_request.number;
-            const siteBaseUrl = process.env.SITE_BASE_URL;
-            const policyMarker = process.env.POLICY_MARKER;
-            const publicPathPrefixes = [
-              "src/content/events/",
-              "src/content/projects/",
-              "src/content/articles/",
-              "src/content/presentations/",
-              "src/content/members/",
-              "src/content/jobs/",
-            ];
-
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner,
-              repo,
-              pull_number: pullNumber,
-              per_page: 100,
-            });
-
-            const publicFiles = files.filter(({ filename }) =>
-              publicPathPrefixes.some((prefix) => filename.startsWith(prefix)),
-            );
-
-            if (publicFiles.length === 0) {
-              core.info("This pull request does not change a public-submittal collection.");
-              return;
-            }
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: pullNumber,
-              per_page: 100,
-            });
-
-            if (comments.some(({ body = "" }) => body.includes(policyMarker))) {
-              core.info("The public-submittal sharing policy has already been posted.");
-              return;
-            }
-
-            const pageUrls = new Set();
-            for (const { filename } of publicFiles) {
-              const relativePath = filename.replaceAll("\\", "/");
-              const fileName = relativePath.split("/").pop() ?? "";
-              const id = fileName.replace(/\.md$/, "");
-
-              if (relativePath.startsWith("src/content/events/") && id) {
-                pageUrls.add(`${siteBaseUrl}/events/#${id}`);
-              } else if (relativePath.startsWith("src/content/projects/") && id) {
-                pageUrls.add(`${siteBaseUrl}/showcase/#${id}`);
-              } else if (relativePath.startsWith("src/content/jobs/") && id) {
-                pageUrls.add(`${siteBaseUrl}/jobs/${id}/`);
-              } else if (relativePath.startsWith("src/content/articles/")) {
-                pageUrls.add(`${siteBaseUrl}/showcase/#articles`);
-              } else if (relativePath.startsWith("src/content/presentations/")) {
-                pageUrls.add(`${siteBaseUrl}/showcase/#presentations`);
-              } else if (relativePath.startsWith("src/content/members/")) {
-                pageUrls.add(`${siteBaseUrl}/community/`);
-              }
-            }
-
-            if (pageUrls.size === 0) {
-              pageUrls.add(`${siteBaseUrl}/`);
-            }
-
-            const links = [...pageUrls]
-              .map((url) => `- [${url}](${url})`)
-              .join("\n");
-            const contributor = context.payload.pull_request.user.login;
-            const body = [
-              `<!-- ${policyMarker} -->`,
-              `Thanks @${contributor} — this public-submittal pull request has been approved by a maintainer.`,
-              "",
-              "**Sharing policy:** Outside Sharing Sundays, the only permitted share for this accepted submission is the relevant link on `agenticbuilders.sg`.",
-              "",
-              "Please do not share the external event, project, article, registration, or company URL, screenshots, copied promotional text, or repeated reposts outside Sharing Sundays. The external links needed for the listing may still appear on the ABC page itself.",
-              "",
-              "After the submission is published, use the relevant ABC page link:",
-              links,
-              "",
-              "The site page is the permitted off-day share; general promotional sharing remains reserved for Sharing Sundays.",
-            ].join("\n");
-
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: pullNumber,
-              body,
-            });
+          name: public-submittal-policy-pr
+          path: pull-request-number.txt
+          retention-days: 1
+      - run: echo "An approval was submitted; the trusted notifier will evaluate it."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,12 @@ Start with the guide matching the thing you want to add:
 - Add an article: [`docs/add-article.md`](./docs/add-article.md)
 - Agent contribution map (exact paths for coding agents): [`docs/agent-access.md`](./docs/agent-access.md)
 
+## Public-submittal sharing
+
+When a public-submittal pull request is accepted, see [`docs/public-submittal-sharing.md`](./docs/public-submittal-sharing.md) for the sharing policy.
+
+Outside Sharing Sundays, the only permitted share is the relevant link on [`agenticbuilders.sg`](https://agenticbuilders.sg/). Do not share the external event, project, article, registration, or company link, screenshots, copied promotional text, or repeated reposts outside the Sunday window.
+
 ## Beginner Setup
 
 You need:

--- a/docs/public-submittal-sharing.md
+++ b/docs/public-submittal-sharing.md
@@ -1,0 +1,20 @@
+# Public-Submittal Sharing Policy
+
+This policy applies when a public submission is accepted for the Agentic Builders Collective website, including an event, presentation, project, article, member profile, or job post.
+
+## Outside Sharing Sundays
+
+Outside the regular Sharing Sundays window, the only permitted share for an accepted public submission is a link to the relevant page on [agenticbuilders.sg](https://agenticbuilders.sg/).
+
+That means:
+
+- Share the ABC page link only.
+- Do not share the external event, project, article, registration, or company URL as the off-day submission.
+- Do not substitute screenshots, clips, copied promotional text, or repeated reposts for the ABC page link.
+- Avoid excessive repetition even when sharing on a permitted day.
+
+The external links needed to describe or register for an item may still appear on the ABC page itself. This policy governs what the contributor shares in the community outside Sharing Sundays.
+
+## Approval message
+
+When a maintainer approves a public-submittal pull request, GitHub automatically posts this policy in the pull request. The contributor should wait until the item is published, then use the supplied `agenticbuilders.sg` page link if sharing outside Sharing Sundays.

--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -104,6 +104,16 @@ const whatsappUrl = "https://chat.whatsapp.com/Be8X9lVJQET4JfkKMW5Qxn";
   </section>
 
   <section>
+    <h3 class="section-label">Public-submittal sharing</h3>
+    <p>
+      When a public event, presentation, project, article, profile, or job submission is accepted for the site, the contributor may share it outside Sharing Sundays only as a link to the relevant page on <a href="https://agenticbuilders.sg/" class="muted-link" target="_blank" rel="noopener">agenticbuilders.sg</a>.
+    </p>
+    <p style="margin-top: 12px;">
+      Outside Sharing Sundays, do not share the external event, project, article, registration, or company URL, screenshots, copied promotional text, or repeated reposts. External links needed for the listing may still appear on the ABC page itself.
+    </p>
+  </section>
+
+  <section>
     <h3 class="section-label">Admin contact</h3>
     <p>
       Reach the whole team at <a href="mailto:hello@agenticbuilders.sg" class="muted-link">hello@agenticbuilders.sg</a>, or DM <a href="/community/#jensen-loke" class="muted-link">Jensen Loke</a>, <a href="/community/#yj-soon" class="muted-link">YJ Soon</a>, <a href="/community/#ian-choo" class="muted-link">Ian Choo</a>, or <a href="/community/#chris-pecaut" class="muted-link">Chris Pecaut</a> directly in the WhatsApp group.


### PR DESCRIPTION
## What changed

- Add a public-submittal sharing policy covering events, presentations, projects, articles, profiles, and job posts.
- Reiterate that outside Sharing Sundays, the only permitted share is the relevant link on `https://agenticbuilders.sg/`.
- Add a reusable public-submittal PR template and update the job-post template.
- Add a public guidelines section.
- Add a GitHub Actions workflow that posts the policy automatically when a maintainer approves a PR changing a public content collection.

## Workflow behavior

- Runs on `pull_request_review` submissions.
- Requires an approving review from an owner, member, or collaborator.
- Ignores non-public/content-only PRs.
- Generates the relevant `agenticbuilders.sg` page link when possible.
- Uses a marker to avoid duplicate comments.
- Does not check out or execute contributor code.

## Validation

- `pnpm check` — passed with 0 errors and 3 pre-existing hints.
- `pnpm build` — passed; 15 pages built.
- Workflow JavaScript syntax check — passed.
- `git diff --cached --check` — passed.

## Review note

This is intentionally a draft for review of the exact wording and the maintainer-association filter before activation.
