### PR TITLE
Add Code Riff Live with Gijs Verheijke at Lorong AI

### DIFF
--- a/src/content/events/2026-08-19-code-riff-live-gijs-verheijke-at-lorong-ai.md
+++ b/src/content/events/2026-08-19-code-riff-live-gijs-verheijke-at-lorong-ai.md
@@ -1,0 +1,27 @@
+---
+title: "Code Riff Live: His AI Agent Ships While He Sleeps. What Would You Hand Over? w/ Gijs Verheijke"
+date: 2026-08-19
+kind: "external"
+time: "2:00 PM - 3:30 PM SGT"
+venue: "Lorong AI @ One-North, 69 Ayer Rajah Cres., Level 3 Vidacity, Singapore 139961"
+venueUrl: "https://lorong.ai"
+registrationUrl: "https://luma.com/gpsousn2"
+attendance: 0
+speakers:
+  - personId: gijs-verheijke
+hosts:
+  - personId: eric-tan
+  - personId: yaohong-chng
+  - name: Lorong AI
+sharedBy:
+  - personId: eric-tan
+tags: ["podcast", "openclaw", "agents", "live-recording"]
+status: "upcoming"
+---
+A live recording of the Code Riff podcast at Lorong AI, part of their Off-Script series. Eric Tan and Yaohong Chng talk to Gijs Verheijke, AI Lead at Carousell and previously founder and CEO of Ox Street.
+
+Can an agent run a business without much human oversight? Gijs has one called Maggie running a SaaS that makes money.
+
+We get into his OpenClaw setup, securing agent workflows in production, where LLMs are still dumb in ways you have to engineer around, knowledge graphs versus skills, AI at Carousell, and his move from finance to tech.
+
+Seats are capped to keep it conversational, so registration is by approval. Questions you submit at sign-up shape what we ask. Phones on silent while we record.


### PR DESCRIPTION
Adds one new event to `src/content/events/` for a live Code Riff podcast recording with Gijs Verheijke (AI Lead at Carousell, former founder & CEO of Ox Street) on 19 August at Lorong AI @ One-North.

Presented by Lorong AI as part of its Off-Script series, so this is `kind: external` with `sharedBy: eric-tan`. Hosts are Eric Tan and Yaohong Chng plus Lorong AI as the presenting organisation. Gijs is listed as speaker.

Follows `docs/add-event.md` and `docs/id-guidelines.md`. All three `personId` references (`gijs-verheijke`, `eric-tan`, `yaohong-chng`) resolve to existing members. Change is additive only, no unrelated entries reformatted.

## Public-submittal checklist

- [x] This PR adds or updates a public event, presentation, project, article, member profile, or job post.
- [x] The relevant collection guide and `docs/id-guidelines.md` have been followed.
- [x] `pnpm check` passes.
- [x] `pnpm build` passes.

## Sharing policy

Outside Sharing Sundays, the only permitted share for an accepted submission is the relevant link on [agenticbuilders.sg](https://agenticbuilders.sg/).

- [x] I understand that I should not share the external event, project, article, registration, or company URL outside Sharing Sundays.
- [x] I understand that screenshots, copied promotional text, and repeated reposts are not substitutes for the ABC page link outside Sharing Sundays.

## Validation

- `pnpm check` — 0 errors, 0 warnings, 1 pre-existing hint.
- `pnpm build` — passed, 16 pages built. Event renders on `/events/`.

## Admin review

- [ ] Approved for publication on the Agentic Builders Collective website.
