### PR TITLE
Add Tony Pelosi to member list

### DIFF
--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -337,3 +337,18 @@
   github: ""
   addedAt: "2026-07-01T12:01:18Z"
   featured: false
+
+- id: tony-pelosi
+  name: Tony Pelosi
+  aliases:
+    - apelosi
+    - tonypelosi
+  tagline: Full-stack Product Builder
+  company: Arevio Technology Partners, LLC
+  website: https://anthonypelosi.com/
+  linkedin: https://www.linkedin.com/in/apelosi
+  github: https://github.com/apelosi
+  youtube: http://www.youtube.com/user/anthonypelosi
+  twitter: https://twitter.com/apelosi
+  addedAt: "2026-08-09T10:05:52Z"
+  featured: false


### PR DESCRIPTION
Adds a new member entry for Tony Pelosi to `src/content/members/members.yaml`, following `docs/add-person.md`.

- id: `tony-pelosi` (checked for collisions, none found)
- `pnpm check` and `pnpm build` both pass