### PR TITLE
fix: archive Code Riff and refresh listings

### DIFF
--- a/src/content/events/2026-05-28-abc-at-amcham.md
+++ b/src/content/events/2026-05-28-abc-at-amcham.md
@@ -4,7 +4,7 @@ date: 2026-05-28
 kind: "meetup"
 time: "6:00 PM – 9:00 PM SGT"
 venue: "AmChamSG @ Shaw Centre"
-venueUrl: "https://maps.app.goo.gl/?q=1+Scotts+Rd+Shaw+Centre+Singapore+228208"
+venueUrl: "https://www.google.com/maps/search/?api=1&query=The%20American%20Chamber%20Of%20Commerce%20in%20Singapore%20%28AmChamSG%29&query_place_id=ChIJeSOUoI0Z2jERwGgwv36RNVo"
 sponsorName: "SG Code Campus"
 sponsorUrl: "https://sgcodecampus.com"
 registrationUrl: "https://luma.com/2q4yargk"

--- a/src/content/events/2026-08-19-code-riff-live-gijs-verheijke-at-lorong-ai.md
+++ b/src/content/events/2026-08-19-code-riff-live-gijs-verheijke-at-lorong-ai.md
@@ -16,7 +16,7 @@ hosts:
 sharedBy:
   - personId: eric-tan
 tags: ["podcast", "openclaw", "agents", "live-recording"]
-status: "upcoming"
+status: "past"
 ---
 A live recording of the Code Riff podcast at Lorong AI, part of their Off-Script series. Eric Tan and Yaohong Chng talk to Gijs Verheijke, AI Lead at Carousell and previously founder and CEO of Ox Street.
 

--- a/src/content/jobs/deployed-engineer-apac-cognition.md
+++ b/src/content/jobs/deployed-engineer-apac-cognition.md
@@ -8,7 +8,7 @@ employmentType: full-time
 applyUrl: https://jobs.ashbyhq.com/cognition/b73fd66a-f43b-4240-95c2-7a76b4ffb0c6
 contactEmail: nathan.wangliao@cognition.ai
 postedAt: 2026-05-21
-expiresAt: 2026-08-19
+expiresAt: 2026-11-19
 submittedBy:
   personId: kevin-lee
 tags:


### PR DESCRIPTION
## Summary
- mark the 19 August Code Riff external event as past
- extend Cognition's Deployed Engineer listing through 19 November 2026
- replace the invalid AmCham archive venue URL with a Google Maps Search link

## Verification
- `git diff --check`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm check`
- `corepack pnpm build`
- confirmed the replacement map URL returns HTTP 200

## Adversarial review
Completed three independent high-reasoning Codex reviews covering correctness, validation/date edge cases, and scope/operational risk. No actionable issues found.