### PR TITLE
Add event: SISC Gambling AI Chapter (2026-08-28)

### DIFF
--- a/src/content/events/2026-08-28-sisc-gambling-ai-chapter.md
+++ b/src/content/events/2026-08-28-sisc-gambling-ai-chapter.md
@@ -1,0 +1,26 @@
+---
+title: "Super-Individual Secret Club (SISC): The Gambling AI Chapter"
+date: 2026-08-28
+kind: external
+time: "7:00 PM - 10:00 PM SGT"
+venue: "Singapore (Bukit Merah, exact address shared with registered guests)"
+venueUrl: ""
+registrationUrl: "https://lu.ma/v5g03bmh"
+hosts:
+  - name: .SISC
+tags:
+  - ai
+  - gambling
+  - poker
+status: upcoming
+---
+
+Welcome to The Super-Individual Secret Club — The 1st Human Alliance in the Agentic Era. Builders, thinkers, and explorers who see AI as more than a tool. No noise, no lurking — just sharp questions and real conversations with people who actually use what they talk about.
+
+We'll explore how AI is transforming betting — from predictive analytics, autonomous agents, personalized strategies, and automated bankroll management to faster, smarter, data-driven wagering. For operators, AI is reshaping the house through smarter pricing, automated risk management, fraud detection, customer engagement, and compliance. As AI advances on both sides, the industry must balance innovation with integrity, security, regulation, and responsible betting. Expect demos, discussion, and ideas worth stealing.
+
+**Agenda**
+
+- 7:00–7:30 PM: Registration
+- 7:30–9:00 PM: Ice breaker & Core Discussions
+- 9:00 PM onwards: Networking


### PR DESCRIPTION
## Summary

- Adds external event `src/content/events/2026-08-28-sisc-gambling-ai-chapter.md`
- Event: **Super-Individual Secret Club (SISC): The Gambling AI Chapter**
- Date: 2026-08-28, 7:00 PM – 10:00 PM SGT, Singapore (Bukit Merah)
- Host: .SISC — community event on AI in gambling/betting
- Kind: `external`, Status: `upcoming`
- Registration: https://lu.ma/v5g03bmh

## Notes

- Venue exact address is guest-only on Luma; noted in venue field
- No `sharedBy` set — submitter not yet listed in members/organisers