### PR TITLE
Add AI for Mechanical Engineers event — Aug 26, Hopscotch, Gardens by the BayFeat/ai for mechanical engineers aug26

### DIFF
--- a/src/content/events/2026-08-26-ai-for-mechanical-engineers.md
+++ b/src/content/events/2026-08-26-ai-for-mechanical-engineers.md
@@ -4,7 +4,7 @@ date: 2026-08-26
 kind: "external"
 time: "6:30 PM - 10:30 PM SGT"
 venue: "Hopscotch, Gardens by the Bay, Singapore"
-venueUrl: "https://www.google.com/maps/search/?api=1&query=1.2794636441623644%2C103.86104006605811"
+venueUrl: "https://maps.app.goo.gl/kbYreeemodXMhs1o7"
 registrationUrl: "https://luma.com/w2m8byzo"
 hosts:
   - name: "Joseph Douglas"

--- a/src/content/events/2026-08-26-ai-for-mechanical-engineers.md
+++ b/src/content/events/2026-08-26-ai-for-mechanical-engineers.md
@@ -1,0 +1,49 @@
+---
+title: "AI for Mechanical Engineers"
+date: 2026-08-26
+kind: "external"
+time: "6:30 PM - 10:30 PM SGT"
+venue: "Hopscotch, Gardens by the Bay, Singapore"
+venueUrl: "https://www.google.com/maps/search/?api=1&query=1.2794636441623644%2C103.86104006605811"
+registrationUrl: "https://luma.com/w2m8byzo"
+hosts:
+  - name: "Joseph Douglas"
+tags:
+  - "Physical AI"
+  - "mechanical engineering"
+  - "hardware"
+  - "roundtable"
+status: "upcoming"
+---
+
+Most of what gets said about AI and engineering is written by people who have never taken a part to production. This evening is the opposite of that.
+
+**AI for Mechanical Engineers** is a single evening in Singapore for practicing engineers, engineering leaders, and technical founders who want a straight answer to one question: what does AI actually do for mechanical engineering work today, and what is still marketing?
+
+No panel platitudes. No demo theater. One talk, one roundtable, dinner, and a room full of people who ship hardware.
+
+## The talk
+
+Joseph Douglas, founder and CEO of 3DScribe, on why CAD geometry is mute to AI, and what happens when it isn't. Joe has spent 13 years in 3D graphics and design for manufacture across the US and Asia, from injection molding tooling in Foshan to building the platform that turns CAD assemblies into knowledge AI can reason over. He will show live systems, not slides about the future: assemblies where every part carries its purpose, and AI agents that answer questions about machines the way a senior service engineer would.
+
+Expect specifics. Where current models fail on real assemblies. What "AI-ready CAD" actually requires. Why after-sales service, not design, is where AI hits the P&L first.
+
+## The roundtable
+
+A moderated working session, not a Q&A line at a microphone. Bring the problem you are actually dealing with: documentation debt, support teams that don't know the product, training that takes too long, customers who can't self-serve. We will work through what is solvable now and what isn't.
+
+## Dinner and networking
+
+Food and drinks are served. The room is deliberately small and curated: engineers, engineering managers, and founders in hardware, manufacturing, and industrial products. You will leave with people worth knowing.
+
+## Who this event is for
+
+Mechanical, manufacturing, and product engineers. Engineering and service leaders. Technical founders building physical products. If your work involves parts, assemblies, tooling, or the people who support them, this is your room.
+
+This is not an event for AI tourists. Registration is reviewed and approval is required. Seats are limited to keep the roundtable useful.
+
+## About the host
+
+Joseph Douglas — founder and CEO of 3DScribe. 13 years in 3D graphics and design for manufacture across the US and Asia.
+
+This event is co-located with AIMX Singapore: https://aimx.global/aimx-singapore-2026/


### PR DESCRIPTION
Co-located with AIMX Singapore. External event hosted by 3DScribe.

Date & Time: Wednesday Aug 26, 6:30–10:30 PM SGT. 
Registration: https://luma.com/w2m8byzo
Venue: Hopscotch, Gardens by the Bay — https://maps.app.goo.gl/kbYreeemodXMhs1o7

Thank you very much, 😁