### PR TITLE
Add Carlos Chacon and Singapore MCP

### DIFF
--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -352,3 +352,16 @@
   twitter: https://twitter.com/apelosi
   addedAt: "2026-08-09T10:05:52Z"
   featured: false
+
+- id: carlos-chacon
+  name: Carlos Chacon
+  aliases:
+    - Carlos
+  tagline: Building agents and multi-agent systems globally, with practical AI workflows for Singapore SMEs.
+  company: Olano AI
+  website: https://olano.ai
+  linkedin: https://www.linkedin.com/in/cchacon
+  github: https://github.com/cchacons
+  twitter: https://x.com/cchakons
+  addedAt: "2026-08-22T06:01:13Z"
+  featured: false

--- a/src/content/projects/mcp-singapore.md
+++ b/src/content/projects/mcp-singapore.md
@@ -1,0 +1,18 @@
+---
+title: Singapore MCP
+makers:
+  - personId: carlos-chacon
+url: https://github.com/olano-ai/mcp-singapore
+github: https://github.com/olano-ai/mcp-singapore
+builtWith:
+  - Model Context Protocol
+featured: false
+summary: An open-source suite of 291 Singapore-focused MCP tools, agent skills, and Claude plugins for evidence-based AI workflows using public data.
+date: 2026-08-21
+---
+
+Singapore MCP by Olano AI is an open-source suite of 291 tools for Claude, Codex, and other AI agents to research Singapore property, MRT and LRT, transport, companies, weather, the economy, finance, and public services.
+
+It includes eight specialised agent skills and Claude plugins that help agents select appropriate tools, combine data across agencies, and explain source coverage and limitations. Builders can install the full suite or use focused profiles for property, mobility, business, economy, civic, and finance.
+
+Singapore MCP is part of Olano AI's broader work on agent and multi-agent systems. Olano.ai is the global platform, while Olano.sg is the Singapore AI Studio building practical agent workflows for local SMEs.


### PR DESCRIPTION
## Summary
- Add Carlos Chacon to the Agentic Builders Collective member list.
- Add Singapore MCP by Olano AI to the project showcase.
- Link the project to Carlos through the member ID.

Singapore MCP launched on 2026-08-21.

## Validation
- `pnpm check` passed: 0 errors.
- `pnpm build` passed.