### PR TITLE
Add Aung Myint Oo to community members

### DIFF
--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -365,3 +365,16 @@
   twitter: https://x.com/cchakons
   addedAt: "2026-08-22T06:01:13Z"
   featured: false
+- id: aung-myint-oo
+  name: Aung Myint Oo
+  aliases:
+    - AMO
+  tagline: AI & robotics engineer building perception, agents, and learning systems that compound over time.
+  company: Salesbugle
+  website: https://aungmyintoo.com
+  linkedin: https://www.linkedin.com/in/aung-myint-oo99/
+  github: https://github.com/davidamo9
+  youtube: ""
+  twitter: ""
+  addedAt: "2026-08-31T04:12:14Z"
+  featured: false

--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -375,6 +375,6 @@
   linkedin: https://www.linkedin.com/in/aung-myint-oo99/
   github: https://github.com/davidamo9
   youtube: ""
-  twitter: ""
+  twitter: https://x.com/amodev
   addedAt: "2026-08-31T04:12:14Z"
   featured: false


### PR DESCRIPTION
Adds Aung Myint Oo to the community members list, following `docs/add-person.md`.

- Additive entry appended to `src/content/members/members.yaml`; no other entries touched
- kebab-case id `aung-myint-oo`, full https URLs, UTC ISO `addedAt`
- Validated locally: `pnpm check` (0 errors, 0 warnings) and `pnpm build` (16 pages) both pass

Profile:
- **Name:** Aung Myint Oo (AMO)
- **Tagline:** AI & robotics engineer building perception, agents, and learning systems that compound over time.
- **Company:** Salesbugle
- **Website:** https://aungmyintoo.com

https://claude.ai/code/session_01SSQJhHCVWJWPanwTZWKd1k