### PR TITLE
fix: update WhatsApp invite link

### DIFF
--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -1,1 +1,1 @@
-export const whatsappUrl = "https://chat.whatsapp.com/FkPWbdgxBhz8rLPTYTFiGq";
+export const whatsappUrl = "https://chat.whatsapp.com/ERCGtnBgVisEyS8f5YpbdT?mode=gi_t";


### PR DESCRIPTION
## Summary

- update the shared WhatsApp invite URL
- preserve the full mode=gi_t query string across all generated CTAs

## Verification

- live invite returned HTTP 200 and identified itself as abc : hallway chat
- corepack pnpm check (0 errors; 3 existing hints)
- corepack pnpm build (16 pages built)
- git diff --check

## Review

Three independent high-reasoning adversarial reviews were completed before PR creation, covering correctness/regressions, tests/types/edge cases, and scope/security/release risk. No actionable issues were found.