### PR TITLE
feat: add IntelWave engineer job

### DIFF
--- a/src/content/jobs/lead-ai-system-engineer-intelwave.md
+++ b/src/content/jobs/lead-ai-system-engineer-intelwave.md
@@ -1,0 +1,51 @@
+---
+title: Lead AI System Engineer
+company: IntelWave Pte Ltd
+companyUrl: https://intelwave.ai
+location: Singapore
+workMode: onsite
+employmentType: full-time
+contactEmail: tech@intelwave.ai
+postedAt: 2026-09-04
+expiresAt: 2026-12-03
+submittedBy:
+  personId: han
+tags:
+  - agentic-ai
+  - ai-systems
+  - backend
+  - fastapi
+  - aws
+  - integrations
+  - realtime
+status: open
+---
+
+IntelWave is building an agentic AI system that integrates deeply with external services such as payments, document workflows, and communications. The system operates as a realtime, cloud-native platform. We are looking for someone who has built and shipped systems like this and can explain why the pieces fit together, not just how to wire them up.
+
+## What you will do
+
+- Build and operate the backend, integrations, and infrastructure for an agentic AI system.
+- Integrate third-party services and handle failure modes, webhooks, idempotency, and retries.
+- Build realtime communication between backend services and the frontend.
+- Design and operate AWS infrastructure across serverless, microservices, compute, storage, networking, and security services.
+- Build and deploy non-trivial FastAPI services with async request handling, authentication, and background task processing.
+
+## What we are looking for
+
+- Practical experience building and shipping LLM-powered or agentic systems with multi-step reasoning and actions.
+- Experience designing evaluations, handling failures and hallucinations, and deciding when humans should be in the loop.
+- Experience shipping stateful third-party API integrations, such as payment processing, document attestation or e-signature workflows, transactional email, or Playwright-based outreach.
+- Hands-on experience with WebSockets or long polling, including the tradeoffs and failure modes of each approach.
+- Broad AWS experience across services such as Lambda, Athena, CloudWatch, S3, EC2, Lightsail, IAM, VPCs, and security groups.
+- Experience building and deploying a non-trivial FastAPI service in a real or production-adjacent context.
+- Strong systems thinking and communication skills. You should be able to explain architectural tradeoffs to both business stakeholders and senior engineers.
+
+## What to send us
+
+Instead of a traditional application, please include:
+
+- Links to relevant repositories, deployed projects, or case studies.
+- A short note about one project where the why mattered as much as the how.
+
+Email your resume and supporting documents to [tech@intelwave.ai](mailto:tech@intelwave.ai).

--- a/src/content/jobs/lead-ai-system-engineer-intelwave.md
+++ b/src/content/jobs/lead-ai-system-engineer-intelwave.md
@@ -9,7 +9,7 @@ contactEmail: tech@intelwave.ai
 postedAt: 2026-09-04
 expiresAt: 2026-12-03
 submittedBy:
-  personId: han
+  personId: leong-han-wai
 tags:
   - agentic-ai
   - ai-systems

--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -379,7 +379,7 @@
   addedAt: "2026-08-31T04:12:14Z"
   featured: false
 
-- id: han
+- id: leong-han-wai
   name: Leong Han Wai
   aliases:
     - Han

--- a/src/content/members/members.yaml
+++ b/src/content/members/members.yaml
@@ -378,3 +378,17 @@
   twitter: https://x.com/amodev
   addedAt: "2026-08-31T04:12:14Z"
   featured: false
+
+- id: han
+  name: Leong Han Wai
+  aliases:
+    - Han
+  tagline: ""
+  company: IntelWave
+  website: https://www.intelwave.ai
+  linkedin: https://www.linkedin.com/in/hanwai
+  github: ""
+  youtube: ""
+  twitter: ""
+  addedAt: "2026-09-04T03:49:33Z"
+  featured: false


### PR DESCRIPTION
## Summary

- Add the Lead AI System Engineer role at IntelWave Pte Ltd.
- Add Leong Han Wai as a community member.
- Link the job submission to the new member profile.

## Validation

- `pnpm check`
- `pnpm build`

Both commands pass. `pnpm check` reports one pre-existing hint in `src/components/SiteHead.astro`.